### PR TITLE
Add more statistics to backend

### DIFF
--- a/WalletWasabi.Backend/Controllers/BlockchainController.cs
+++ b/WalletWasabi.Backend/Controllers/BlockchainController.cs
@@ -25,6 +25,7 @@ using WalletWasabi.Extensions;
 using WalletWasabi.Helpers;
 using WalletWasabi.Logging;
 using WalletWasabi.Models;
+using WalletWasabi.WabiSabi.Backend.Statistics;
 
 namespace WalletWasabi.Backend.Controllers;
 
@@ -424,15 +425,17 @@ public class BlockchainController : ControllerBase
 	{
 		try
 		{
+			var before = DateTimeOffset.UtcNow;
 			uint256 txId = new(transactionId);
 
 			var cacheKey = $"{nameof(GetUnconfirmedTransactionChainAsync)}_{txId}";
-
-			return await Cache.GetCachedResponseAsync(
+			var ret = await Cache.GetCachedResponseAsync(
 				cacheKey,
 				action: (string request, CancellationToken token) => GetUnconfirmedTransactionChainNoCacheAsync(txId, token),
 				options: UnconfirmedTrasanctionChainCacheEntryOptions,
 				cancellationToken);
+			RequestTimeStatista.Instance.Add("unconfirmed-transaction-chain", DateTimeOffset.UtcNow - before);
+			return ret;
 		}
 		catch (OperationCanceledException)
 		{

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.Partial.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.Partial.cs
@@ -12,6 +12,8 @@ using WalletWasabi.WabiSabi.Models;
 using WalletWasabi.WabiSabi.Models.MultipartyTransaction;
 using WalletWasabi.Logging;
 using WalletWasabi.Crypto.Randomness;
+using WalletWasabi.WabiSabi.Backend.Statistics;
+
 namespace WalletWasabi.WabiSabi.Backend.Rounds;
 
 public partial class Arena : IWabiSabiApiRequestHandler
@@ -36,6 +38,7 @@ public partial class Arena : IWabiSabiApiRequestHandler
 
 		using (await AsyncLock.LockAsync(cancellationToken).ConfigureAwait(false))
 		{
+			var beforeInside = DateTimeOffset.UtcNow;
 			var round = GetRound(request.RoundId);
 
 			// Compute but don't commit updated coinjoin to round state, it will
@@ -122,7 +125,7 @@ public partial class Arena : IWabiSabiApiRequestHandler
 			int currentBlockHeight = await Rpc.GetBlockCountAsync(cancellationToken).ConfigureAwait(false);
 
 			CoinVerifier?.TryScheduleVerification(coin, round.InputRegistrationTimeFrame.EndTime, confirmations, oneHop: oneHop, currentBlockHeight, cancellationToken);
-
+			RequestTimeStatista.Instance.Add("input-registration-inside", DateTimeOffset.UtcNow - beforeInside);
 			return new(alice.Id,
 				commitAmountCredentialResponse,
 				commitVsizeCredentialResponse,
@@ -134,6 +137,7 @@ public partial class Arena : IWabiSabiApiRequestHandler
 	{
 		using (await AsyncLock.LockAsync(cancellationToken).ConfigureAwait(false))
 		{
+			var beforeInside = DateTimeOffset.UtcNow;
 			var round = GetRound(request.RoundId, Phase.OutputRegistration);
 			var alice = GetAlice(request.AliceId, round);
 			if (alice.IsCoordinationFeeExempted && request.AffiliationId != AffiliationConstants.DefaultAffiliationId)
@@ -143,6 +147,7 @@ public partial class Arena : IWabiSabiApiRequestHandler
 			}
 			alice.ReadyToSign = true;
 			NotifyAffiliation(round.Id, alice.Coin, request.AffiliationId);
+			RequestTimeStatista.Instance.Add("ready-to-sign-inside", DateTimeOffset.UtcNow - beforeInside);
 		}
 	}
 
@@ -150,9 +155,11 @@ public partial class Arena : IWabiSabiApiRequestHandler
 	{
 		using (await AsyncLock.LockAsync(cancellationToken).ConfigureAwait(false))
 		{
+			var beforeInside = DateTimeOffset.UtcNow;
 			var round = GetRound(request.RoundId, Phase.InputRegistration);
 
 			round.Alices.RemoveAll(x => x.Id == request.AliceId && x.ConfirmedConnection == false);
+			RequestTimeStatista.Instance.Add("input-unregistration-inside", DateTimeOffset.UtcNow - beforeInside);
 		}
 	}
 
@@ -181,6 +188,7 @@ public partial class Arena : IWabiSabiApiRequestHandler
 
 		using (await AsyncLock.LockAsync(cancellationToken).ConfigureAwait(false))
 		{
+			var beforeInside = DateTimeOffset.UtcNow;
 			round = GetRound(request.RoundId, Phase.InputRegistration, Phase.ConnectionConfirmation);
 
 			alice = GetAlice(request.AliceId, round);
@@ -200,6 +208,7 @@ public partial class Arena : IWabiSabiApiRequestHandler
 			{
 				throw new WabiSabiProtocolException(WabiSabiProtocolErrorCode.IncorrectRequestedAmountCredentials, $"Round ({request.RoundId}): Incorrect requested amount credentials.");
 			}
+			RequestTimeStatista.Instance.Add("connection-confirmation-inside1", DateTimeOffset.UtcNow - beforeInside);
 		}
 
 		var amountZeroCredentialTask = round.AmountCredentialIssuer.HandleRequestAsync(request.ZeroAmountCredentialRequests, cancellationToken);
@@ -215,6 +224,7 @@ public partial class Arena : IWabiSabiApiRequestHandler
 
 		using (await AsyncLock.LockAsync(cancellationToken).ConfigureAwait(false))
 		{
+			var beforeInside = DateTimeOffset.UtcNow;
 			alice = GetAlice(request.AliceId, round);
 
 			switch (round.Phase)
@@ -223,6 +233,7 @@ public partial class Arena : IWabiSabiApiRequestHandler
 					var commitAmountZeroCredentialResponse = await amountZeroCredentialTask.ConfigureAwait(false);
 					var commitVsizeZeroCredentialResponse = await vsizeZeroCredentialTask.ConfigureAwait(false);
 					alice.SetDeadlineRelativeTo(round.ConnectionConfirmationTimeFrame.Duration);
+					RequestTimeStatista.Instance.Add("connection-confirmation-inside2", DateTimeOffset.UtcNow - beforeInside);
 					return new(
 						commitAmountZeroCredentialResponse,
 						commitVsizeZeroCredentialResponse);
@@ -241,7 +252,7 @@ public partial class Arena : IWabiSabiApiRequestHandler
 					// Update the coinjoin state, adding the confirmed input.
 					round.CoinjoinState = round.Assert<ConstructionState>().AddInput(alice.Coin, alice.OwnershipProof, round.CoinJoinInputCommitmentData);
 					alice.ConfirmedConnection = true;
-
+					RequestTimeStatista.Instance.Add("connection-confirmation-inside2", DateTimeOffset.UtcNow - beforeInside);
 					return response;
 
 				default:
@@ -259,6 +270,7 @@ public partial class Arena : IWabiSabiApiRequestHandler
 	{
 		using (await AsyncLock.LockAsync(cancellationToken).ConfigureAwait(false))
 		{
+			var beforeInside = DateTimeOffset.UtcNow;
 			var round = GetRound(request.RoundId, Phase.OutputRegistration);
 
 			var credentialAmount = -request.AmountCredentialRequests.Delta;
@@ -307,6 +319,7 @@ public partial class Arena : IWabiSabiApiRequestHandler
 			// Update round state.
 			round.Bobs.Add(bob);
 			round.CoinjoinState = newState;
+			RequestTimeStatista.Instance.Add("output-registration-inside", DateTimeOffset.UtcNow - beforeInside);
 		}
 
 		return EmptyResponse.Instance;
@@ -316,12 +329,14 @@ public partial class Arena : IWabiSabiApiRequestHandler
 	{
 		using (await AsyncLock.LockAsync(cancellationToken).ConfigureAwait(false))
 		{
+			var beforeInside = DateTimeOffset.UtcNow;
 			var round = GetRound(request.RoundId, Phase.TransactionSigning);
 
 			var state = round.Assert<SigningState>().AddWitness((int)request.InputIndex, request.Witness);
 
 			// at this point all of the witnesses have been verified and the state can be updated
 			round.CoinjoinState = state;
+			RequestTimeStatista.Instance.Add("transaction-signature-inside", DateTimeOffset.UtcNow - beforeInside);
 		}
 	}
 
@@ -330,7 +345,9 @@ public partial class Arena : IWabiSabiApiRequestHandler
 		Round round;
 		using (await AsyncLock.LockAsync(cancellationToken).ConfigureAwait(false))
 		{
+			var beforeInside = DateTimeOffset.UtcNow;
 			round = GetRound(request.RoundId, Phase.ConnectionConfirmation, Phase.OutputRegistration);
+			RequestTimeStatista.Instance.Add("credential-issuance-inside", DateTimeOffset.UtcNow - beforeInside);
 		}
 
 		if (request.RealAmountCredentialRequests.Delta != 0)

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -86,6 +86,7 @@ public partial class Arena : PeriodicRunner
 		var before = DateTimeOffset.UtcNow;
 		using (await AsyncLock.LockAsync(cancel).ConfigureAwait(false))
 		{
+			var beforeInside = DateTimeOffset.UtcNow;
 			TimeoutRounds();
 
 			TimeoutAlices();
@@ -107,9 +108,10 @@ public partial class Arena : PeriodicRunner
 
 			// RoundStates have to contain all states. Do not change stateId=0.
 			SetRoundStates();
+
+			RequestTimeStatista.Instance.Add("arena-period-inside", DateTimeOffset.UtcNow - beforeInside);
 		}
-		var duration = DateTimeOffset.UtcNow - before;
-		RequestTimeStatista.Instance.Add("arena-period", duration);
+		RequestTimeStatista.Instance.Add("arena-period", DateTimeOffset.UtcNow - before);
 
 		ThreadPool.GetMaxThreads(out int maxWorkerThreads, out int maxCompletionPortThreads);
 		ThreadPool.GetAvailableThreads(out int availableWorkerThreads, out int availableCompletionPortThreads);

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -110,6 +110,14 @@ public partial class Arena : PeriodicRunner
 		}
 		var duration = DateTimeOffset.UtcNow - before;
 		RequestTimeStatista.Instance.Add("arena-period", duration);
+
+		ThreadPool.GetMaxThreads(out int maxWorkerThreads, out int maxCompletionPortThreads);
+		ThreadPool.GetAvailableThreads(out int availableWorkerThreads, out int availableCompletionPortThreads);
+		RequestTimeStatista.Instance.Add("maxWorker-Threads", maxWorkerThreads);
+		RequestTimeStatista.Instance.Add("availableWorker-Threads", availableWorkerThreads);
+		RequestTimeStatista.Instance.Add("maxCompletionPort-Threads", maxCompletionPortThreads);
+		RequestTimeStatista.Instance.Add("availableCompletionPort-Threads", availableCompletionPortThreads);
+		RequestTimeStatista.Instance.TryDisplay();
 	}
 
 	private void SetRoundStates()

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.cs
@@ -119,7 +119,7 @@ public partial class Arena : PeriodicRunner
 		RequestTimeStatista.Instance.Add("availableWorker-Threads", availableWorkerThreads);
 		RequestTimeStatista.Instance.Add("maxCompletionPort-Threads", maxCompletionPortThreads);
 		RequestTimeStatista.Instance.Add("availableCompletionPort-Threads", availableCompletionPortThreads);
-		RequestTimeStatista.Instance.TryDisplay();
+		RequestTimeStatista.Instance.FlushStatisticsToLogsIfTimeElapsed();
 	}
 
 	private void SetRoundStates()

--- a/WalletWasabi/WabiSabi/Backend/Statistics/RequestTimeStatista.cs
+++ b/WalletWasabi/WabiSabi/Backend/Statistics/RequestTimeStatista.cs
@@ -1,9 +1,7 @@
-using NBitcoin;
 using System.Collections.Generic;
 using System.Linq;
 using WalletWasabi.Crypto;
 using WalletWasabi.Logging;
-using static WalletWasabi.Wallets.FilterProcessor.BlockDownloadService;
 
 namespace WalletWasabi.WabiSabi.Backend.Statistics;
 
@@ -72,7 +70,7 @@ public class RequestTimeStatista
 		}
 	}
 
-	public void TryDisplay()
+	public void FlushStatisticsToLogsIfTimeElapsed()
 	{
 		if (DateTimeOffset.UtcNow - LastDisplayed < DisplayFrequency)
 		{

--- a/WalletWasabi/WabiSabi/Backend/Statistics/RequestTimeStatista.cs
+++ b/WalletWasabi/WabiSabi/Backend/Statistics/RequestTimeStatista.cs
@@ -61,7 +61,7 @@ public class RequestTimeStatista
 			foreach (var request in Requests.OrderByDescending(x => x.Value.Count))
 			{
 				var seconds = request.Value.Select(x => x.Duration.TotalSeconds);
-				Logger.LogInfo($"Responded to '{request.Key}'\t {request.Value.Count} times. Median: {seconds.Median():0.0}s Average: {seconds.Average():0.0}s Largest {seconds.Max():0.0}s");
+				Logger.LogInfo($"Responded to '{request.Key}'\t {request.Value.Count} times. Median: {seconds.Median():0.000}s Average: {seconds.Average():0.000}s Largest {seconds.Max():0.000}s");
 			}
 
 			LastDisplayed = DateTimeOffset.UtcNow;


### PR DESCRIPTION
Backend "hiccups" are happening multiple times per day. Response times can go up 60-70 seconds for minutes. After that, everything goes back to normal. 

We are investigating and need more information. We are sniffing around the lock first. 

I want to deploy it as soon as possible because the hiccups are happening. 

Commit by commit review is easier. 