### PR TITLE
Update dependencies for deterministic build

### DIFF
--- a/WalletWasabi.sln
+++ b/WalletWasabi.sln
@@ -25,6 +25,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		README.md = README.md
 		Settings.StyleCop = Settings.StyleCop
 		NuGet.Config = NuGet.Config
+		deps.nix = deps.nix
+		flake.lock = flake.lock
+		flake.nix = flake.nix
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WalletWasabi.Packager", "WalletWasabi.Packager\WalletWasabi.Packager.csproj", "{8BE916A0-1F3F-4757-BAD9-BFBAB8EAC3C2}"

--- a/deps.nix
+++ b/deps.nix
@@ -10,6 +10,7 @@
   (fetchNuGet { pname = "Microsoft.Build.Runtime"; version = "15.3.409"; sha256 = "135ycnqz5jfg61y5zaapgc7xdpjx2aq4icmxb9ph7h5inl445q7q"; })
   (fetchNuGet { pname = "Microsoft.Build.Tasks.Core"; version = "15.3.409"; sha256 = "135swyygp7cz2civwsz6a7dj7h8bzp7yrybmgxjanxwrw66hm933"; })
   (fetchNuGet { pname = "Microsoft.Build.Utilities.Core"; version = "15.3.409"; sha256 = "1p8a0l9sxmjj86qha748qjw2s2n07q8mn41mj5r6apjnwl27ywnf"; })
+  (fetchNuGet { pname = "Microsoft.CodeAnalysis.BannedApiAnalyzers"; version = "3.3.4"; sha256 = "1vzrni7n94f17bzc13lrvcxvgspx9s25ap1p005z6i1ikx6wgx30"; })
   (fetchNuGet { pname = "Microsoft.CSharp"; version = "4.3.0"; sha256 = "0gw297dgkh0al1zxvgvncqs0j15lsna9l1wpqas4rflmys440xvb"; })
   (fetchNuGet { pname = "Microsoft.CSharp"; version = "4.7.0"; sha256 = "0gd67zlw554j098kabg887b5a6pq9kzavpa3jjy5w53ccjzjfy8j"; })
   (fetchNuGet { pname = "Microsoft.Data.Sqlite"; version = "8.0.0"; sha256 = "02y3y3x4ggxcjcrnazwxdi08xmwabaalrm40rwjdij072x5va3yi"; })


### PR DESCRIPTION
Because https://github.com/zkSNACKs/WalletWasabi/pull/12797 didn't updated the deps.nix file with the new dependency, nix cannot build (we cannot deploy) because it is deterministic. The problem is showed here: https://github.com/zkSNACKs/WalletWasabi/pull/12797#issuecomment-2057045070

This PR updates the dependencies and add the nix files ad solution items just for convenience.

