### PR TITLE
Fix AS percent for SemiPrivate coins when AS Target is 2

### DIFF
--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -231,7 +231,11 @@ public class Wallet : BackgroundService, IWallet
 
 	public int GetPrivacyPercentage()
 	{
-		var currentPrivacyScore = Coins.Sum(x => x.Amount.Satoshi * Math.Min(x.HdPubKey.AnonymitySet - 1, x.IsPrivate(AnonScoreTarget) ? AnonScoreTarget - 1 : AnonScoreTarget - 2));
+		var currentPrivacyScore = Coins.Sum(x => x.Amount.Satoshi * Math.Min(
+			x.HdPubKey.AnonymitySet - 1,
+			x.IsPrivate(AnonScoreTarget) ?
+				AnonScoreTarget - 1 :
+				Math.Max(1, AnonScoreTarget - 2)));
 		var maxPrivacyScore = Coins.TotalAmount().Satoshi * (AnonScoreTarget - 1);
 		int pcPrivate = maxPrivacyScore == 0M ? 0 : (int)(currentPrivacyScore * 100 / maxPrivacyScore);
 


### PR DESCRIPTION
Fixes #11832

When the `AnonScore Target` is `2`, the `AnonScore` percentage is not computed correctly for `Semi-Private` coins that are not `Private` because of #10885 because `AnonScoreTarget - 2 = 0` so we multiply by `0`