### PR TITLE
Fix CI failing with ubuntu version increase

### DIFF
--- a/azure-pipelines-linux.yml
+++ b/azure-pipelines-linux.yml
@@ -7,7 +7,7 @@ variables:
 jobs:
 - job: Linux
   pool:
-    vmImage: 'ubuntu-20.04'
+    vmImage: 'ubuntu-22.04'
   steps:
   - task: UseDotNet@2
     displayName: 'Install .NET'


### PR DESCRIPTION
fixes: #12855 

##Description
Hwi broke the CI for some reason in the Mock Tests place. But in the local machines, the tests are passed. 

##Solution
I needed to increase the Ubuntu version number in linux.yml to 22.04. 
