### PR TITLE
Do not abort round in input registration

### DIFF
--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/CoordinatorTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Backend/CoordinatorTests.cs
@@ -99,6 +99,7 @@ public class CoordinatorTests
 
 			// Register our coin..
 			round.CoinjoinState = round.AddInput(alice.Coin, alice.OwnershipProof, WabiSabiFactory.CreateCommitmentData(round.Id));
+			round.SetPhase(Phase.ConnectionConfirmation);
 			coordinator.Arena.Rounds.Add(round);
 
 			// .. spend it also in another transaction paying less fee rate than the coinjoin

--- a/WalletWasabi/WabiSabi/Backend/Rounds/Arena.Partial.cs
+++ b/WalletWasabi/WabiSabi/Backend/Rounds/Arena.Partial.cs
@@ -418,7 +418,7 @@ public partial class Arena : IWabiSabiApiRequestHandler
 
 	public (uint256 RoundId, FeeRate MiningFeeRate)[] GetRoundsContainingOutpoints(IEnumerable<OutPoint> outPoints) =>
 		Rounds
-		.Where(r => r.Phase != Phase.Ended)
+		.Where(r => r.Phase != Phase.Ended && r.Phase >= Phase.ConnectionConfirmation)
 		.SelectMany(r => r.CoinjoinState.Inputs.Select(a => (RoundId: r.Id, MiningFeeRate: r.Parameters.MiningFeeRate, Coin: a)))
 		.Where(x => outPoints.Any(outpoint => outpoint == x.Coin.Outpoint))
 		.Select(x => (x.RoundId, x.MiningFeeRate))


### PR DESCRIPTION
The DoS prevention was aborting round in input-registration phase when Arena already can detect that and remove offending Alices without needing to disrupt the round.

Update: this reduces the need to call GetTxOutAsync method so often and reduce the workload for the bitcoin node. 