### PR TITLE
Create Library and LaunchAgents folder if they don't exist

### DIFF
--- a/WalletWasabi.Fluent/Helpers/MacOsStartupHelper.cs
+++ b/WalletWasabi.Fluent/Helpers/MacOsStartupHelper.cs
@@ -34,24 +34,24 @@ public static class MacOsStartupHelper
 		await DeleteLoginItemIfExistsAsync().ConfigureAwait(false);
 
 		string homeDir = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-
 		var libraryDir = Path.Combine(homeDir, "Library");
-		if (!Directory.Exists(libraryDir))
-		{
-			Logger.LogInfo("Creating Library directory because it doesn't exist.");
-			Directory.CreateDirectory(libraryDir);
-		}
-
 		var launchAgentsDir = Path.Combine(libraryDir, "LaunchAgents");
-		if (!Directory.Exists(launchAgentsDir))
-		{
-			Logger.LogInfo("Creating LaunchAgents directory because it doesn't exist.");
-			Directory.CreateDirectory(launchAgentsDir);
-		}
-
 		var plistPath = Path.Combine(launchAgentsDir, Constants.SilentPlistName);
+
 		if (runOnSystemStartup)
 		{
+			if (!Directory.Exists(libraryDir))
+			{
+				Logger.LogInfo("Creating Library directory because it doesn't exist.");
+				Directory.CreateDirectory(libraryDir);
+			}
+
+			if (!Directory.Exists(launchAgentsDir))
+			{
+				Logger.LogInfo("Creating LaunchAgents directory because it doesn't exist.");
+				Directory.CreateDirectory(launchAgentsDir);
+			}
+
 			await File.WriteAllTextAsync(plistPath, PlistContent).ConfigureAwait(false);
 		}
 		else if (File.Exists(plistPath))

--- a/WalletWasabi.Fluent/Helpers/MacOsStartupHelper.cs
+++ b/WalletWasabi.Fluent/Helpers/MacOsStartupHelper.cs
@@ -1,6 +1,4 @@
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
 using WalletWasabi.Helpers;
 using WalletWasabi.Logging;
@@ -36,14 +34,27 @@ public static class MacOsStartupHelper
 		await DeleteLoginItemIfExistsAsync().ConfigureAwait(false);
 
 		string homeDir = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
-		string plistPath = Path.Combine(homeDir, "Library/LaunchAgents/", Constants.SilentPlistName);
 
-		var fileExists = File.Exists(plistPath);
+		var libraryDir = Path.Combine(homeDir, "Library");
+		if (!Directory.Exists(libraryDir))
+		{
+			Logger.LogInfo("Creating Library directory because it doesn't exist.");
+			Directory.CreateDirectory(libraryDir);
+		}
+
+		var launchAgentsDir = Path.Combine(libraryDir, "LaunchAgents");
+		if (!Directory.Exists(launchAgentsDir))
+		{
+			Logger.LogInfo("Creating LaunchAgents directory because it doesn't exist.");
+			Directory.CreateDirectory(launchAgentsDir);
+		}
+
+		var plistPath = Path.Combine(launchAgentsDir, Constants.SilentPlistName);
 		if (runOnSystemStartup)
 		{
 			await File.WriteAllTextAsync(plistPath, PlistContent).ConfigureAwait(false);
 		}
-		else if (fileExists && !runOnSystemStartup)
+		else if (File.Exists(plistPath))
 		{
 			File.Delete(plistPath);
 		}

--- a/WalletWasabi.Fluent/Helpers/StartupHelper.cs
+++ b/WalletWasabi.Fluent/Helpers/StartupHelper.cs
@@ -1,5 +1,7 @@
+using System;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
+using WalletWasabi.Logging;
 
 namespace WalletWasabi.Fluent.Helpers;
 
@@ -9,17 +11,25 @@ public static class StartupHelper
 
 	public static async Task ModifyStartupSettingAsync(bool runOnSystemStartup)
 	{
-		if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+		try
 		{
-			WindowsStartupHelper.AddOrRemoveRegistryKey(runOnSystemStartup);
+			if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+			{
+				WindowsStartupHelper.AddOrRemoveRegistryKey(runOnSystemStartup);
+			}
+			else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+			{
+				await LinuxStartupHelper.AddOrRemoveDesktopFileAsync(runOnSystemStartup).ConfigureAwait(false);
+			}
+			else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+			{
+				await MacOsStartupHelper.AddOrRemoveStartupItemAsync(runOnSystemStartup).ConfigureAwait(false);
+			}
 		}
-		else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+		catch (Exception ex)
 		{
-			await LinuxStartupHelper.AddOrRemoveDesktopFileAsync(runOnSystemStartup).ConfigureAwait(false);
-		}
-		else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-		{
-			await MacOsStartupHelper.AddOrRemoveStartupItemAsync(runOnSystemStartup).ConfigureAwait(false);
+			// Suppress exception to avoid potential crashes.
+			Logger.LogError($"{ex}");
 		}
 	}
 }


### PR DESCRIPTION
Fixes a bug introduced in this release that can cause a crash to users in cases where they have installed Wasabi on macOs since a really long time, enabled `RunOnSystemStartUp`, but don't have anything else on their session that runs on startup.

`LaunchAgents` doesn't exist by default, `Library` does but I check it as well in case user deleted it.

I tested and it fixes the problem, sorry for that, didn't realize while reviewing that those folders didn't exist by default!!