### PR TITLE
Update IndexStore.cs to fix filter migration crash

### DIFF
--- a/WalletWasabi/Stores/IndexStore.cs
+++ b/WalletWasabi/Stores/IndexStore.cs
@@ -12,7 +12,6 @@ using WalletWasabi.Blockchain.BlockFilters;
 using WalletWasabi.Blockchain.Blocks;
 using WalletWasabi.Helpers;
 using WalletWasabi.Logging;
-using WalletWasabi.Models;
 
 namespace WalletWasabi.Stores;
 
@@ -24,6 +23,7 @@ public class IndexStore : IIndexStore, IAsyncDisposable
 	public IndexStore(string workFolderPath, Network network, SmartHeaderChain smartHeaderChain)
 	{
 		SmartHeaderChain = smartHeaderChain;
+		Network = network;
 
 		workFolderPath = Guard.NotNullOrEmptyOrWhitespace(nameof(workFolderPath), workFolderPath, trim: true);
 		IoHelpers.EnsureDirectoryExists(workFolderPath);
@@ -39,9 +39,14 @@ public class IndexStore : IIndexStore, IAsyncDisposable
 			File.Delete(NewIndexFilePath);
 		}
 
+		IndexStorage = CreateIndexStorage();
+	}
+
+	private BlockFilterSqliteStorage CreateIndexStorage()
+	{
 		try
 		{
-			IndexStorage = BlockFilterSqliteStorage.FromFile(dataSource: NewIndexFilePath, startingFilter: StartingFilters.GetStartingFilter(network));
+			return BlockFilterSqliteStorage.FromFile(dataSource: NewIndexFilePath, startingFilter: StartingFilters.GetStartingFilter(Network));
 		}
 		catch (SqliteException ex) when (ex.SqliteExtendedErrorCode == 11) // 11 ~ SQLITE_CORRUPT error code
 		{
@@ -70,6 +75,9 @@ public class IndexStore : IIndexStore, IAsyncDisposable
 	/// <summary>Run migration if SQLite file does not exist.</summary>
 	private bool RunMigration { get; }
 
+	/// <summary>NBitcoin network.</summary>
+	private Network Network { get; }
+
 	private SmartHeaderChain SmartHeaderChain { get; }
 
 	/// <summary>Task completion source that is completed once a <see cref="InitializeAsync(CancellationToken)"/> finishes.</summary>
@@ -78,7 +86,7 @@ public class IndexStore : IIndexStore, IAsyncDisposable
 
 	/// <summary>Filter disk storage.</summary>
 	/// <remarks>Guarded by <see cref="IndexLock"/>.</remarks>
-	private BlockFilterSqliteStorage IndexStorage { get; }
+	private BlockFilterSqliteStorage IndexStorage { get; set; }
 
 	/// <summary>Guards <see cref="IndexStorage"/>.</summary>
 	private AsyncLock IndexLock { get; } = new();
@@ -195,10 +203,13 @@ public class IndexStore : IIndexStore, IAsyncDisposable
 			Logger.LogError(ex);
 
 			SqliteConnection.ClearAllPools();
+			IndexStorage.Dispose();
 
 			// Do not run migration code again if it fails.
 			File.Delete(NewIndexFilePath);
 			File.Delete(OldIndexFilePath);
+
+			IndexStorage = CreateIndexStorage();
 		}
 	}
 


### PR DESCRIPTION
Fixes https://github.com/zkSNACKs/WalletWasabi/issues/11638

Properly closing the sql before deleting the sqlite file.
Need to dispose the whole IndexStore on migration issue.

