### PR TITLE
Show & separate Network Fee and CJ Fee for CJs

### DIFF
--- a/WalletWasabi.Fluent/Models/Wallets/TransactionModel.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/TransactionModel.cs
@@ -59,6 +59,11 @@ public partial class TransactionModel : ReactiveObject
 
 	private Money GetAmount()
 	{
+		if (IsCoinjoin)
+		{
+			return Amount;
+		}
+
 		return Amount < Money.Zero
 			? Amount + (Fee ?? Money.Zero)
 			: Amount;

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/Details/CoinJoinDetailsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/Details/CoinJoinDetailsViewModel.cs
@@ -21,6 +21,8 @@ public partial class CoinJoinDetailsViewModel : RoutableViewModel
 	[AutoNotify] private bool _isConfirmationTimeVisible;
 	[AutoNotify] private FeeRate? _feeRate;
 	[AutoNotify] private bool _feeRateVisible;
+	[AutoNotify] private Amount? _fee;
+	[AutoNotify] private bool _feeVisible;
 
 	public CoinJoinDetailsViewModel(UiContext uiContext, IWalletModel wallet, TransactionModel transaction)
 	{
@@ -56,6 +58,8 @@ public partial class CoinJoinDetailsViewModel : RoutableViewModel
 			IsConfirmationTimeVisible = ConfirmationTime.HasValue && ConfirmationTime != TimeSpan.Zero;
 			FeeRate = transaction.FeeRate;
 			FeeRateVisible = FeeRate != FeeRate.Zero;
+			Fee = _wallet.AmountProvider.Create(transaction.Fee);
+			FeeVisible = Fee is not null && Fee.HasBalance;
 		}
 	}
 }

--- a/WalletWasabi.Fluent/Views/Wallets/Home/History/Details/CoinJoinDetailsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/History/Details/CoinJoinDetailsView.axaml
@@ -62,9 +62,9 @@
 
       <!-- CJ fee  -->
       <PreviewItem Icon="{StaticResource btc_logo}"
-                     Label="Fees"
+                     Label="Coinjoin Fees"
                      CopyableContent="{Binding CoinJoinFeeAmount.Btc, Converter={x:Static conv:MoneyConverters.ToFeeWithoutUnit}}"
-                     ToolTip.Tip="Total user cost">
+                     ToolTip.Tip="Coordinator fees and the mining fees for the user">
         <AmountControl Classes="Fee" Amount="{Binding CoinJoinFeeAmount}" />
       </PreviewItem>
 

--- a/WalletWasabi.Fluent/Views/Wallets/Home/History/Details/CoinJoinDetailsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/History/Details/CoinJoinDetailsView.axaml
@@ -63,7 +63,8 @@
       <!-- CJ fee  -->
       <PreviewItem Icon="{StaticResource btc_logo}"
                      Label="Fees"
-                     CopyableContent="{Binding CoinJoinFeeAmount.Btc, Converter={x:Static conv:MoneyConverters.ToFeeWithoutUnit}}">
+                     CopyableContent="{Binding CoinJoinFeeAmount.Btc, Converter={x:Static conv:MoneyConverters.ToFeeWithoutUnit}}"
+                     ToolTip.Tip="Total user cost">
         <AmountControl Classes="Fee" Amount="{Binding CoinJoinFeeAmount}" />
       </PreviewItem>
 
@@ -71,7 +72,8 @@
       <PreviewItem Icon="{StaticResource btc_logo}"
                      IsVisible="{Binding FeeVisible}"
                      Label="Mining Fee"
-                     CopyableContent="{Binding Fee.Btc, Converter={x:Static conv:MoneyConverters.ToFeeWithoutUnit}}">
+                     CopyableContent="{Binding Fee.Btc, Converter={x:Static conv:MoneyConverters.ToFeeWithoutUnit}}"
+                     ToolTip.Tip="Total mining fee paid by all participants">
         <AmountControl Classes="Fee" Amount="{Binding Fee}" />
       </PreviewItem>
 

--- a/WalletWasabi.Fluent/Views/Wallets/Home/History/Details/CoinJoinDetailsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/History/Details/CoinJoinDetailsView.axaml
@@ -67,6 +67,14 @@
         <AmountControl Classes="Fee" Amount="{Binding CoinJoinFeeAmount}" />
       </PreviewItem>
 
+      <!-- Mining fee  -->
+      <PreviewItem Icon="{StaticResource btc_logo}"
+                     IsVisible="{Binding FeeVisible}"
+                     Label="Mining Fee"
+                     CopyableContent="{Binding Fee.Btc, Converter={x:Static conv:MoneyConverters.ToFeeWithoutUnit}}">
+        <AmountControl Classes="Fee" Amount="{Binding Fee}" />
+      </PreviewItem>
+
       <!-- Confirmation Time -->
       <PreviewItem IsVisible="{Binding IsConfirmationTimeVisible}"
                      Icon="{StaticResource timer_regular}"

--- a/WalletWasabi/Blockchain/Transactions/TransactionSummary.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionSummary.cs
@@ -6,16 +6,22 @@ namespace WalletWasabi.Blockchain.Transactions;
 
 public class TransactionSummary
 {
-	public TransactionSummary(SmartTransaction tx, Money amount, FeeRate? effectiveFeeRate)
+	public TransactionSummary(SmartTransaction tx, Money amount, FeeRate? effectiveFeeRate, Money? fee)
 	{
 		Transaction = tx;
 		Amount = amount;
 		EffectiveFeeRate = effectiveFeeRate;
+		Fee = fee;
 	}
 
 	public SmartTransaction Transaction { get; }
 	public Money Amount { get; set; }
+
+	// Only available, if we needed the backend's help to calculate tx's fee rate. Use FeeRate().
 	public FeeRate? EffectiveFeeRate { get; }
+
+	// Only available, if we needed the backend's help to calculate tx fee. Use GetFee().
+	public Money? Fee { get; }
 
 	public DateTimeOffset FirstSeen => Transaction.FirstSeen;
 	public LabelsArray Labels => Transaction.Labels;
@@ -27,7 +33,7 @@ public class TransactionSummary
 	public bool IsCPFP => Transaction.IsCPFP;
 	public bool IsCPFPd => Transaction.IsCPFPd;
 
-	public Money? GetFee() => Transaction.GetFee();
+	public Money? GetFee() => Transaction.GetFee() ?? Fee;
 
 	public FeeRate? FeeRate() => Transaction.TryGetFeeRate(out var feeRate) ? feeRate : EffectiveFeeRate;
 

--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -183,9 +183,10 @@ public class Wallet : BackgroundService, IWallet
 			else
 			{
 				var unconfTransactionChainOfCoin = UnconfirmedTransactionChainProvider.GetUnconfirmedTransactionChain(coin.TransactionId) ?? [];
+				var fee = unconfTransactionChainOfCoin.FirstOrDefault(item => item.TxId == coin.TransactionId)?.Fee;
 				var effectiveFeeRate = FeeHelpers.CalculateEffectiveFeeRateOfUnconfirmedChain(unconfTransactionChainOfCoin);
 
-				mapByTxid.Add(coin.TransactionId, new TransactionSummary(coin.Transaction, coin.Amount, effectiveFeeRate));
+				mapByTxid.Add(coin.TransactionId, new TransactionSummary(coin.Transaction, coin.Amount, effectiveFeeRate, fee));
 			}
 
 			if (coin.SpenderTransaction is { } spenderTransaction)
@@ -199,9 +200,10 @@ public class Wallet : BackgroundService, IWallet
 				else
 				{
 					var unconfTransactionChainOfCoin = UnconfirmedTransactionChainProvider.GetUnconfirmedTransactionChain(coin.TransactionId) ?? [];
+					var fee = unconfTransactionChainOfCoin.FirstOrDefault(item => item.TxId == coin.TransactionId)?.Fee;
 					var effectiveFeeRate = FeeHelpers.CalculateEffectiveFeeRateOfUnconfirmedChain(unconfTransactionChainOfCoin);
 
-					mapByTxid.Add(spenderTxId, new TransactionSummary(spenderTransaction, Money.Zero - coin.Amount, effectiveFeeRate));
+					mapByTxid.Add(spenderTxId, new TransactionSummary(spenderTransaction, Money.Zero - coin.Amount, effectiveFeeRate, fee));
 				}
 			}
 		}


### PR DESCRIPTION
Contributes to https://github.com/zkSNACKs/WalletWasabi/issues/9013
Addresses: https://github.com/zkSNACKs/WalletWasabi/issues/9014#issuecomment-2061097821

![image](https://github.com/zkSNACKs/WalletWasabi/assets/45069029/d7f99f26-13be-4063-a753-f8d853de7f20)

The Tx Fee is called "Mining Fee" in the details. 
The "Fees" stayed the same, which is the "money I lost because of the Amount Decomposer + Coordinator Fee".

The naming, icon, tooltip etc. for this field can be discussed under this PR, but only if you also recommend an alternative for it. 😇