### PR TITLE
Remove unused `Constants.OutputSizeInBytes` constant

### DIFF
--- a/WalletWasabi/Helpers/Constants.cs
+++ b/WalletWasabi/Helpers/Constants.cs
@@ -40,11 +40,6 @@ public static class Constants
 	public const int P2shInputVirtualSize = 297; // we assume a 2-of-n multisig
 	public const int P2shOutputVirtualSize = 32;
 
-	/// <summary>
-	/// OBSOLATED, USE SPECIFIC TYPE
-	/// </summary>
-	public const int OutputSizeInBytes = 33;
-
 	// https://en.bitcoin.it/wiki/Bitcoin
 	// There are a maximum of 2,099,999,997,690,000 Bitcoin elements (called satoshis), which are currently most commonly measured in units of 100,000,000 known as BTC. Stated another way, no more than 21 million BTC can ever be created.
 	public const long MaximumNumberOfSatoshis = 2099999997690000;


### PR DESCRIPTION
It seems that the constants is not used anymore. It looks like we can remove it. 

If somebody is depending on it, it's easy to do it in a 3rd party library.