### PR TITLE
Fix UpdateManager

### DIFF
--- a/WalletWasabi/Services/UpdateManager.cs
+++ b/WalletWasabi/Services/UpdateManager.cs
@@ -100,7 +100,8 @@ public class UpdateManager : IDisposable
 				}
 			} while (tries < MaxTries);
 		}
-		var newStatus = new UpdateStatus(updateStatus.BackendCompatible,
+		var newStatus = new UpdateStatus(
+			updateStatus.BackendCompatible,
 			updateStatus.ClientUpToDate,
 			updateStatus.LegalDocumentsVersion,
 			updateStatus.CurrentBackendMajorVersion,

--- a/WalletWasabi/Services/UpdateManager.cs
+++ b/WalletWasabi/Services/UpdateManager.cs
@@ -131,6 +131,8 @@ public class UpdateManager : IDisposable
 
 				// This should also be done using Tor.
 				// TODO: https://github.com/zkSNACKs/WalletWasabi/issues/8800
+				// Wait a moment to avoid dossing GitHub API.
+				await Task.Delay(2000, cancellationToken).ConfigureAwait(false);
 				Logger.LogInfo($"Trying to download new version: {result.LatestVersion}");
 
 				// Get file stream and copy it to downloads folder to access.
@@ -234,6 +236,8 @@ public class UpdateManager : IDisposable
 
 		try
 		{
+			// Wait a moment to avoid dossing GitHub API.
+			await Task.Delay(2000, cancellationToken).ConfigureAwait(false);
 			using HttpRequestMessage sha256Request = new(HttpMethod.Get, sha256SumsUrl);
 			using HttpResponseMessage sha256Response = await HttpClient.SendAsync(sha256Request, cancellationToken).ConfigureAwait(false);
 			string sha256Content = await sha256Response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
@@ -241,6 +245,7 @@ public class UpdateManager : IDisposable
 			IoHelpers.EnsureContainingDirectoryExists(sha256SumsFilePath);
 			File.WriteAllText(sha256SumsFilePath, sha256Content);
 
+			await Task.Delay(2000, cancellationToken).ConfigureAwait(false);
 			using HttpRequestMessage signatureRequest = new(HttpMethod.Get, wasabiSigUrl);
 			using HttpResponseMessage signatureResponse = await HttpClient.SendAsync(signatureRequest, cancellationToken).ConfigureAwait(false);
 			string signatureContent = await signatureResponse.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);

--- a/WalletWasabi/Services/UpdateManager.cs
+++ b/WalletWasabi/Services/UpdateManager.cs
@@ -129,8 +129,6 @@ public class UpdateManager : IDisposable
 			{
 				EnsureToRemoveCorruptedFiles();
 
-				// This should also be done using Tor.
-				// TODO: https://github.com/zkSNACKs/WalletWasabi/issues/8800
 				// Wait a moment to avoid dossing GitHub API.
 				await Task.Delay(2000, cancellationToken).ConfigureAwait(false);
 				Logger.LogInfo($"Trying to download new version: {result.LatestVersion}");


### PR DESCRIPTION
This PR aims to fix 2 things

6d52ad18812a086a5c4848f5f6e1141b15491696: When we update from major to major, like from 2.0.6 to 2.0.7, it's working fine.
But if there is a hotfix, and the user is still on 2.0.6, we update the `UpdateStatus` object's `ClientVersion` from `2.0.7` to `2.0.7.1`.
This change [will trigger the UpdateChecker](https://github.com/zkSNACKs/WalletWasabi/blob/master/WalletWasabi/Services/UpdateChecker.cs#L38-L43) again and again and again, because it doesn't recognize silent releases, but will see that the `newUpdateStatus` is different then the actual.
With this change I made a new instance of UpdateStatus, so if there is a new version ready to be installed, we won't change the `ClientVersion` of the original object.

3a62045d7a2efa10bba480c9339bd28f15688e7a: As mentioned [here](https://github.com/zkSNACKs/WalletWasabi/issues/12633#issuecomment-2063542406), it could happen that we send requests very fast to GitHub API. Adding delays between calls should help avoiding this error.