### PR TITLE
SQLite: Disable connection pooling for block filter SQLite database

### DIFF
--- a/WalletWasabi/Stores/BlockFilterSqliteStorage.cs
+++ b/WalletWasabi/Stores/BlockFilterSqliteStorage.cs
@@ -42,6 +42,7 @@ public class BlockFilterSqliteStorage : IDisposable
 		{
 			SqliteConnectionStringBuilder builder = new();
 			builder.DataSource = dataSource;
+			builder.Pooling = false;
 
 			SqliteConnection connection = new(builder.ConnectionString);
 			connectionToDispose = connection;

--- a/WalletWasabi/Stores/IndexStore.cs
+++ b/WalletWasabi/Stores/IndexStore.cs
@@ -52,8 +52,6 @@ public class IndexStore : IIndexStore, IAsyncDisposable
 		{
 			Logger.LogError($"Failed to open SQLite storage file because it's corrupted. Deleting the storage file '{NewIndexFilePath}'.");
 
-			// The database file can still be in use, clear all pools to unlock the filter database file.
-			SqliteConnection.ClearAllPools();
 			File.Delete(NewIndexFilePath);
 			throw;
 		}
@@ -193,7 +191,6 @@ public class IndexStore : IIndexStore, IAsyncDisposable
 		}
 		catch (OperationCanceledException)
 		{
-			SqliteConnection.ClearAllPools();
 			throw;
 		}
 		catch (Exception ex)
@@ -201,7 +198,6 @@ public class IndexStore : IIndexStore, IAsyncDisposable
 			Logger.LogError(ex);
 
 			IndexStorage.Dispose();
-			SqliteConnection.ClearAllPools();
 
 			// Do not run migration code again if it fails.
 			File.Delete(NewIndexFilePath);


### PR DESCRIPTION
The idea here is that we don't really use SQLite connection pooling for anything. 

The pooling feature is useful when one creates and tears down connections. We have just one connection though that lives as long as the application lives.