### PR TITLE
Install udevrules with Ubuntu distribution

### DIFF
--- a/WalletWasabi.Packager/Program.cs
+++ b/WalletWasabi.Packager/Program.cs
@@ -36,10 +36,7 @@ public static class Program
 	/// <seealso href="https://docs.microsoft.com/en-us/dotnet/articles/core/rid-catalog"/>
 	private static string[] Targets = new[]
 	{
-		"win-x64",
-		"linux-x64",
-		"osx-x64",
-		"osx-arm64"
+		"linux-x64"
 	};
 
 	private static string VersionPrefix = Constants.ClientVersion.Revision == 0 ? Constants.ClientVersion.ToString(3) : Constants.ClientVersion.ToString();
@@ -473,6 +470,13 @@ public static class Program
 					$"  Built-in Tor, coinjoin, payjoin and coin control features.\n";
 
 				File.WriteAllText(controlFilePath, controlFileContent, Encoding.ASCII);
+
+				string postInstScriptContent = $"#!/bin/sh\n" +
+											   $"/usr/local/bin/wasabiwallet/Microservices/Binaries/lin64/hwi installudevrules\n" +
+											   $"exit 0\n";
+
+				string postInstScriptPath = Path.Combine(debianFolderPath, "postinst");
+				File.WriteAllText(postInstScriptPath, postInstScriptContent, Encoding.ASCII);
 
 				var desktopFilePath = Path.Combine(debUsrAppFolderPath, $"{ExecutableName}.desktop");
 				var desktopFileContent = $"[Desktop Entry]\n" +

--- a/WalletWasabi.Packager/Program.cs
+++ b/WalletWasabi.Packager/Program.cs
@@ -474,9 +474,11 @@ public static class Program
 
 				File.WriteAllText(controlFilePath, controlFileContent, Encoding.ASCII);
 
-				string postInstScriptContent = $"#!/bin/sh\n" +
-											   $"/usr/local/bin/wasabiwallet/Microservices/Binaries/lin64/hwi installudevrules\n" +
-											   $"exit 0\n";
+				string postInstScriptContent = """
+											   #!/bin/sh
+											   /usr/local/bin/wasabiwallet/Microservices/Binaries/lin64/hwi installudevrules\n
+											   exit 0
+											   """.ReplaceLineEndings("\n");
 
 				string postInstScriptPath = Path.Combine(debianFolderPath, "postinst");
 				File.WriteAllText(postInstScriptPath, postInstScriptContent, Encoding.ASCII);

--- a/WalletWasabi.Packager/Program.cs
+++ b/WalletWasabi.Packager/Program.cs
@@ -36,7 +36,10 @@ public static class Program
 	/// <seealso href="https://docs.microsoft.com/en-us/dotnet/articles/core/rid-catalog"/>
 	private static string[] Targets = new[]
 	{
-		"linux-x64"
+		"win-x64",
+		"linux-x64",
+		"osx-x64",
+		"osx-arm64"
 	};
 
 	private static string VersionPrefix = Constants.ClientVersion.Revision == 0 ? Constants.ClientVersion.ToString(3) : Constants.ClientVersion.ToString();

--- a/WalletWasabi.Packager/Program.cs
+++ b/WalletWasabi.Packager/Program.cs
@@ -476,7 +476,7 @@ public static class Program
 
 				string postInstScriptContent = """
 											   #!/bin/sh
-											   /usr/local/bin/wasabiwallet/Microservices/Binaries/lin64/hwi installudevrules\n
+											   /usr/local/bin/wasabiwallet/Microservices/Binaries/lin64/hwi installudevrules
 											   exit 0
 											   """.ReplaceLineEndings("\n");
 


### PR DESCRIPTION
fixes: [#12610](https://github.com/zkSNACKs/WalletWasabi/issues/12610)


The best solution was that under the Ubuntu system, during or somehow after the WW installation, the "installudevrules" command of HWI should be executed to further facilitate usability for the users.

To achieve this, it was necessary to implement the "postinst" script which runs after the installation and performs the necessary steps.