### PR TITLE
`AllFeeEstimate`: Extract 'constants'

### DIFF
--- a/WalletWasabi/Blockchain/Analysis/FeesEstimation/AllFeeEstimate.cs
+++ b/WalletWasabi/Blockchain/Analysis/FeesEstimation/AllFeeEstimate.cs
@@ -1,5 +1,4 @@
 using NBitcoin;
-using NBitcoin.RPC;
 using Newtonsoft.Json;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
@@ -15,18 +14,26 @@ namespace WalletWasabi.Blockchain.Analysis.FeesEstimation;
 [JsonObject(MemberSerialization.OptIn)]
 public class AllFeeEstimate : IEquatable<AllFeeEstimate>
 {
+	private static readonly int[] AllConfirmationTargets = Constants.ConfirmationTargets.Prepend(1).ToArray();
+
+	/// <summary>All allowed target confirmation ranges, i.e. 0-2, 2-3, 3-6, 6-18, ..., 432-1008.</summary>
+	private static readonly IEnumerable<(int Start, int End)> TargetRanges = AllConfirmationTargets
+		.Skip(1)
+		.Zip(AllConfirmationTargets.Skip(1).Prepend(0), (x, y) => (Start: y, End: x));
+
+	/// <summary>
+	/// Constructor takes the input confirmation estimations and filters out all confirmation targets that are not <see cref="Constants.ConfirmationTargets">whitelisted</see>.
+	/// </summary>
+	/// <param name="estimations">Map of confirmation targets to fee rates in satoshis (e.g. confirmation target 1 -> 50 sats/vByte).</param>
 	[JsonConstructor]
 	public AllFeeEstimate(IDictionary<int, int> estimations)
 	{
 		Guard.NotNullOrEmpty(nameof(estimations), estimations);
 
-		var targets = Constants.ConfirmationTargets.Prepend(1).ToArray();
-		var targetRanges = targets.Skip(1).Zip(targets.Skip(1).Prepend(0), (x, y) => (Start: y, End: x));
-
 		var filteredEstimations = estimations
-			.Where(x => x.Key >= targets[0] && x.Key <= targets[^1])
+			.Where(x => x.Key >= AllConfirmationTargets[0] && x.Key <= AllConfirmationTargets[^1])
 			.OrderBy(x => x.Key)
-			.Select(x => (ConfirmationTarget: x.Key, FeeRate: x.Value, Range: targetRanges.First(y => y.Start < x.Key && x.Key <= y.End)))
+			.Select(x => (ConfirmationTarget: x.Key, FeeRate: x.Value, Range: TargetRanges.First(y => y.Start < x.Key && x.Key <= y.End)))
 			.GroupBy(x => x.Range, y => y, (x, y) => (Range: x, BestEstimation: y.Last()))
 			.Select(x => (ConfirmationTarget: x.Range.End, x.BestEstimation.FeeRate));
 


### PR DESCRIPTION
<s>Depends on #12903</s>

Another minor cleanup of `AllFeeEstimate`. This time we just extract stuff that does not change at all and so it is not necessary to re-compute it every time.