### PR TITLE
[UI] MenuItem - make icons less emphazied

### DIFF
--- a/WalletWasabi.Fluent/Styles/MenuItem.axaml
+++ b/WalletWasabi.Fluent/Styles/MenuItem.axaml
@@ -2,4 +2,8 @@
   <Style Selector="MenuItem">
     <Setter Property="CornerRadius" Value="8" />
   </Style>
+
+  <Style Selector="MenuItem > PathIcon">
+    <Setter Property="Opacity" Value="0.6" />
+  </Style>
 </Styles>


### PR DESCRIPTION
Forgot to do it in UI Refreshment. It will make the text more noticeable.

Before:
![image](https://github.com/zkSNACKs/WalletWasabi/assets/16364053/55f6d356-4152-49f0-b8cf-ecf77890cf3e)

After:
![image](https://github.com/zkSNACKs/WalletWasabi/assets/16364053/5283d0ed-09a7-44ec-ad93-aef61b941f68)
