### PR TITLE
[draft] 10 minute confirmation target

### DIFF
--- a/WalletWasabi.Tests/UnitTests/AllFeeEstimateTests.cs
+++ b/WalletWasabi.Tests/UnitTests/AllFeeEstimateTests.cs
@@ -374,14 +374,15 @@ public class AllFeeEstimateTests
 
 		var allFee = new AllFeeEstimate(estimations);
 
-		Assert.Equal(7, allFee.WildEstimations.Count);
-		Assert.Equal(new FeeRate(102m), allFee.WildEstimations[0].feeRate); // 20m
-		Assert.Equal(new FeeRate(20m), allFee.WildEstimations[1].feeRate); // 30m
-		Assert.Equal(new FeeRate(16.666m), allFee.WildEstimations[2].feeRate); // 40m
-		Assert.Equal(new FeeRate(13.333m), allFee.WildEstimations[3].feeRate); // 50m
-		Assert.Equal(new FeeRate(10m), allFee.WildEstimations[4].feeRate); // 1h
-		Assert.Equal(new FeeRate(5.5m), allFee.WildEstimations[5].feeRate); // 2h
-		Assert.Equal(new FeeRate(1m), allFee.WildEstimations[6].feeRate); // 3h
+		Assert.Equal(8, allFee.WildEstimations.Count);
+		Assert.Equal(new FeeRate(155m), allFee.WildEstimations[0].feeRate); // 10m
+		Assert.Equal(new FeeRate(102m), allFee.WildEstimations[1].feeRate); // 20m
+		Assert.Equal(new FeeRate(20m), allFee.WildEstimations[2].feeRate); // 30m
+		Assert.Equal(new FeeRate(16.666m), allFee.WildEstimations[3].feeRate); // 40m
+		Assert.Equal(new FeeRate(13.333m), allFee.WildEstimations[4].feeRate); // 50m
+		Assert.Equal(new FeeRate(10m), allFee.WildEstimations[5].feeRate); // 1h
+		Assert.Equal(new FeeRate(5.5m), allFee.WildEstimations[6].feeRate); // 2h
+		Assert.Equal(new FeeRate(1m), allFee.WildEstimations[7].feeRate); // 3h
 
 		Assert.Equal(TimeSpan.FromMinutes(10), allFee.EstimateConfirmationTime(new FeeRate(200m)));
 		Assert.Equal(TimeSpan.FromMinutes(20), allFee.EstimateConfirmationTime(new FeeRate(102.1m)));

--- a/WalletWasabi/Blockchain/Analysis/FeesEstimation/AllFeeEstimate.cs
+++ b/WalletWasabi/Blockchain/Analysis/FeesEstimation/AllFeeEstimate.cs
@@ -128,6 +128,13 @@ public class AllFeeEstimate : IEquatable<AllFeeEstimate>
 				}
 			}
 
+			if (wildEstimations.Count > 0 && wildEstimations[0].timeSpan == TimeSpan.FromMinutes(20))
+			{
+				// 1.51 is just a made up coefficient. See https://github.com/zkSNACKs/WalletWasabi/issues/11358#issue-1862849028.
+				FeeRate feeRate = new(Math.Ceiling(wildEstimations[0].feeRate.SatoshiPerByte * 1.51m));
+				wildEstimations = wildEstimations.Prepend((TimeSpan.FromMinutes(10), feeRate)).ToList();
+			}
+
 			return wildEstimations;
 		}
 	}


### PR DESCRIPTION
Fixes #11358
<s>Depends on #12910</s>

## Introduction

The problem here is that `conf_target` in `estimatesmartfee conf_target ( "estimate_mode" )` [cannot be](https://github.com/bitcoin/bitcoin/blob/67c0d93982ad214f5e0c9509e9dc3d6d792ad97c/src/policy/fees.cpp#L884-L885) `1` because:

>  The request target will be clamped between 2 and the highest target fee estimation is able to return based on how long it has been running.

\[[Source](https://developer.bitcoin.org/reference/rpc/estimatesmartfee.html)\]


## Testing

Given that RegTest does not really have history and thus it is handles [specially](https://github.com/zkSNACKs/WalletWasabi/blob/9786a249e3685978a823eb891831f00062fe3dc9/WalletWasabi/Extensions/RPCClientExtensions.cs#L66-L68), we need to test `RegTest` as well.

## Resources

* For anyone wondering why `smart` in `estimatesmartfee`. There used to be `estimatefee` which was superseded by `estimatesmartfee` in https://github.com/bitcoin/bitcoin/pull/11031.
* https://github.com/bitcoin/bitcoin/issues/27995 - *Improving fee estimation accuracy*
* https://bitcoin.stackexchange.com/questions/121384/why-does-bitcoin-cores-estimatesmartfee-return-a-higher-feerate-than-necessar
    > The Bitcoin Core fee estimator does not aim to provide the minimum possible feerate to be included within `N` blocks. It aims to provide the minimum feerate such as one has a high degree of confidence the transactions will be mined within `N` blocks.
    >
    > It therefore tends to often give a higher estimate than appears to have been necessary on any particular transaction. But it also provides a guarantee that over time a high percentage of the transactions created with the recommended feerate will have been mined within the required N blocks.
* https://github.com/bitcoin/bitcoin/issues/27995 - *Improving fee estimation accuracy*
    > [The estimator] is solely based on historical data (looking at how long mempool transactions take to confirm), it cannot react quickly to changing conditions.