### PR TITLE
[UI] Increase height of tiles

### DIFF
--- a/WalletWasabi.Fluent/Views/Wallets/Home/WalletTiles.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/WalletTiles.axaml
@@ -13,7 +13,7 @@
       <ItemsControl.Styles>
         <Style Selector="ItemsControl > ContentPresenter">
           <Setter Property="Width" Value="310" />
-          <Setter Property="Height" Value="140" />
+          <Setter Property="Height" Value="150" />
         </Style>
       </ItemsControl.Styles>
       <ItemsControl.ItemsPanel>


### PR DESCRIPTION
The drop shadow for the Light theme made it narrow on each theme. The privacy control tile is crowed, so this PR mitigates the issue.

(The long-term goal is to have better-designed tiles)

Before:
![image](https://github.com/zkSNACKs/WalletWasabi/assets/16364053/f26a4a08-ba50-447d-acd3-f094ec05a613)

After:
![image](https://github.com/zkSNACKs/WalletWasabi/assets/16364053/519d8b93-87f0-4792-a2e2-bdfdc3905350)

