### PR TITLE
Update WasabiCompatibility.md because of HWI

### DIFF
--- a/WalletWasabi.Documentation/ClientRelease/ReleaseNotesTemplate.md
+++ b/WalletWasabi.Documentation/ClientRelease/ReleaseNotesTemplate.md
@@ -34,7 +34,7 @@ Wasabi uses [reproducible builds](https://reproducible-builds.org/), which you c
 - Windows 10 1607+
 - Windows 11 22000+
 - macOS 12.0+
-- Ubuntu 20.04+
+- Ubuntu 22.04+
 - Fedora 37+
 - Debian 11+
 ---

--- a/WalletWasabi.Documentation/WasabiCompatibility.md
+++ b/WalletWasabi.Documentation/WasabiCompatibility.md
@@ -7,7 +7,7 @@ This document lists all the officially supported software and devices by Wasabi 
 - Windows 10 1607+
 - Windows 11 22000+
 - macOS 12.0+
-- Ubuntu 20.04+
+- Ubuntu 22.04+
 - Fedora 37+
 - Debian 11+
 


### PR DESCRIPTION

As long as HWI doesn't come out with a new version, we need to increase the minimum Ubuntu version number, because currently, it can't run on the older 20.04 version.

Main issue:
https://github.com/bitcoin-core/HWI/issues/732

