### PR TITLE
Add command line option `--LogModes`

### DIFF
--- a/WalletWasabi.Daemon/Config.cs
+++ b/WalletWasabi.Daemon/Config.cs
@@ -1,3 +1,4 @@
+using Microsoft.Extensions.Logging;
 using NBitcoin;
 using System;
 using System.Collections;
@@ -8,6 +9,7 @@ using System.Linq;
 using System.Net;
 using WalletWasabi.Exceptions;
 using WalletWasabi.Helpers;
+using WalletWasabi.Logging;
 using WalletWasabi.Models;
 using WalletWasabi.Tor;
 using WalletWasabi.Userfacing;
@@ -22,6 +24,14 @@ public class Config
 	{
 		PersistentConfig = persistentConfig;
 		CliArgs = cliArgs;
+
+		LogMode[] defaultLogModes;
+
+#if RELEASE
+		defaultLogModes = [LogMode.Console, LogMode.File];
+#else
+		defaultLogModes = [LogMode.Debug, LogMode.Console, LogMode.File];
+#endif
 
 		Data = new()
 		{
@@ -109,6 +119,9 @@ public class Config
 			[ nameof(LogLevel)] = (
 				"The level of detail in the logs: trace, debug, info, warning, error, or critical",
 				GetStringValue("LogLevel", value: "", cliArgs)),
+			[ nameof(LogModes)] = (
+				"The logging modes: console, and file (for multiple values use comma as a separator)",
+				GetLogModeArrayValue("LogModes", arrayValues: defaultLogModes, cliArgs)),
 			[ nameof(EnableGpu)] = (
 				"Use a GPU to render the user interface",
 				GetBoolValue("EnableGpu", PersistentConfig.EnableGpu, cliArgs)),
@@ -162,6 +175,7 @@ public class Config
 	public Money DustThreshold => GetEffectiveValue<MoneyValue, Money>(nameof(DustThreshold));
 	public bool BlockOnlyMode => GetEffectiveValue<BoolValue, bool>(nameof(BlockOnlyMode));
 	public string LogLevel => GetEffectiveValue<StringValue, string>(nameof(LogLevel));
+	public LogMode[] LogModes => GetEffectiveValue<LogModeArrayValue, LogMode[]>(nameof(LogModes));
 
 	public bool EnableGpu => GetEffectiveValue<BoolValue, bool>(nameof(EnableGpu));
 	public string CoordinatorIdentifier => GetEffectiveValue<StringValue, string>(nameof(CoordinatorIdentifier));
@@ -331,6 +345,30 @@ public class Config
 		return new StringArrayValue(arrayValues, arrayValues, ValueSource.Disk);
 	}
 
+	private static LogModeArrayValue GetLogModeArrayValue(string key, LogMode[] arrayValues, string[] cliArgs)
+	{
+		if (GetOverrideValue(key, cliArgs, out string? overrideValue, out ValueSource? valueSource))
+		{
+			LogMode[] logModes = overrideValue.Split(',', StringSplitOptions.RemoveEmptyEntries)
+				.Where(x => !string.IsNullOrWhiteSpace(x)) // Filter our whitespace-only elements.
+				.Select(x =>
+				{
+					if (!Enum.TryParse(x.Trim(), ignoreCase: true, out LogMode logMode))
+					{
+						throw new NotSupportedException($"Logging mode '{x}' is not supported.");
+					}
+
+					return logMode;
+				})
+				.ToHashSet() // Remove duplicates.
+				.ToArray();
+
+			return new LogModeArrayValue(arrayValues, logModes, valueSource.Value);
+		}
+
+		return new LogModeArrayValue(arrayValues, arrayValues, ValueSource.Disk);
+	}
+
 	private static bool GetOverrideValue(string key, string[] cliArgs, [NotNullWhen(true)] out string? overrideValue, [NotNullWhen(true)] out ValueSource? valueSource)
 	{
 		// CLI arguments have higher precedence than environment variables.
@@ -421,6 +459,7 @@ public class Config
 	private record StringValue(string Value, string EffectiveValue, ValueSource ValueSource) : ITypedValue<string>;
 	private record NullableStringValue(string? Value, string? EffectiveValue, ValueSource ValueSource) : ITypedValue<string?>;
 	private record StringArrayValue(string[] Value, string[] EffectiveValue, ValueSource ValueSource) : ITypedValue<string[]>;
+	private record LogModeArrayValue(LogMode[] Value, LogMode[] EffectiveValue, ValueSource ValueSource) : ITypedValue<LogMode[]>;
 	private record NetworkValue(Network Value, Network EffectiveValue, ValueSource ValueSource) : ITypedValue<Network>;
 	private record MoneyValue(Money Value, Money EffectiveValue, ValueSource ValueSource) : ITypedValue<Money>;
 	private record EndPointValue(EndPoint Value, EndPoint EffectiveValue, ValueSource ValueSource) : ITypedValue<EndPoint>;

--- a/WalletWasabi.Daemon/Global.cs
+++ b/WalletWasabi.Daemon/Global.cs
@@ -59,7 +59,8 @@ public class Global
 			controlPort: config.TorControlPort,
 			torFolder: config.TorFolder,
 			bridges: config.TorBridges,
-			owningProcessId: Environment.ProcessId);
+			owningProcessId: Environment.ProcessId,
+			log: Config.LogModes.Contains(LogMode.File));
 
 		HostedServices = new HostedServices();
 		EventBus = new EventBus();

--- a/WalletWasabi.Daemon/WasabiAppBuilder.cs
+++ b/WalletWasabi.Daemon/WasabiAppBuilder.cs
@@ -149,7 +149,8 @@ public class WasabiApplication
 		LogLevel logLevel = Enum.TryParse(Config.LogLevel, ignoreCase: true, out LogLevel parsedLevel)
 			? parsedLevel
 			: LogLevel.Info;
-		Logger.InitializeDefaults(Path.Combine(Config.DataDir, "Logs.txt"), logLevel);
+
+		Logger.InitializeDefaults(Path.Combine(Config.DataDir, "Logs.txt"), logLevel, Config.LogModes);
 	}
 
 	private void ShowHelp()

--- a/WalletWasabi/Logging/Logger.cs
+++ b/WalletWasabi/Logging/Logger.cs
@@ -67,18 +67,21 @@ public static class Logger
 	/// </para>
 	/// </summary>
 	/// <param name="logLevel">Use <c>null</c> to use default <see cref="LogLevel"/> or a custom value to force non-default <see cref="LogLevel"/>.</param>
-	public static void InitializeDefaults(string filePath, LogLevel? logLevel = null)
+	/// <param name="logModes">Use <c>null</c> to use default <see cref="LogMode">logging modes</see> or custom values to force non-default logging modes.</param>
+	public static void InitializeDefaults(string filePath, LogLevel? logLevel = null, LogMode[]? logModes = null)
 	{
 		SetFilePath(filePath);
 
 #if RELEASE
-		SetMinimumLevel(logLevel ??= LogLevel.Info);
-		SetModes(LogMode.Console, LogMode.File);
-
+		logLevel ??= LogLevel.Info;
+		logModes ??= [LogMode.Console, LogMode.File];
 #else
-		SetMinimumLevel(logLevel ??= LogLevel.Debug);
-		SetModes(LogMode.Debug, LogMode.Console, LogMode.File);
+		logLevel ??= LogLevel.Debug;
+		logModes ??= [LogMode.Debug, LogMode.Console, LogMode.File];
 #endif
+
+		SetMinimumLevel(logLevel.Value);
+		SetModes(logModes);
 
 		lock (Lock)
 		{

--- a/WalletWasabi/Tor/TorSettings.cs
+++ b/WalletWasabi/Tor/TorSettings.cs
@@ -31,20 +31,21 @@ public class TorSettings
 		int controlPort = DefaultControlPort,
 		string? torFolder = null,
 		string[]? bridges = null,
-		int? owningProcessId = null)
+		int? owningProcessId = null,
+		bool log = true)
 	{
 		IsCustomTorFolder = torFolder is not null;
 
-        bool defaultWasabiTorPorts = socksPort == DefaultSocksPort && controlPort == DefaultControlPort;
+		bool defaultWasabiTorPorts = socksPort == DefaultSocksPort && controlPort == DefaultControlPort;
 
 		// Use different ports when user overrides Tor folder to avoid accessing the same control_auth_cookie file.
-        if (IsCustomTorFolder && defaultWasabiTorPorts)
-        {
+		if (IsCustomTorFolder && defaultWasabiTorPorts)
+		{
 			socksPort = 37152;
 			controlPort = 37153;
-        }
+		}
 
-        TorBinaryDir = torFolder ?? Path.Combine(MicroserviceHelpers.GetBinaryFolder(), "Tor");
+		TorBinaryDir = torFolder ?? Path.Combine(MicroserviceHelpers.GetBinaryFolder(), "Tor");
 		TorBinaryFilePath = GetTorBinaryFilePath(TorBinaryDir);
 		TorTransportPluginsDir = Path.Combine(TorBinaryDir, "PluggableTransports");
 
@@ -62,15 +63,16 @@ public class TorSettings
 		IoHelpers.EnsureContainingDirectoryExists(LogFilePath);
 		DistributionFolder = distributionFolderPath;
 		TerminateOnExit = terminateOnExit;
+		Log = log;
 		GeoIpPath = Path.Combine(DistributionFolder, "Tor", "Geoip", "geoip");
 		GeoIp6Path = Path.Combine(DistributionFolder, "Tor", "Geoip", "geoip6");
 	}
 
-    /// <summary><c>true</c> if user specified a custom Tor folder to run a (possibly) different Tor binary than the bundled Tor, <c>false</c> otherwise.</summary>
-    public bool IsCustomTorFolder { get; }
+	/// <summary><c>true</c> if user specified a custom Tor folder to run a (possibly) different Tor binary than the bundled Tor, <c>false</c> otherwise.</summary>
+	public bool IsCustomTorFolder { get; }
 
-    /// <summary>Full directory path where Tor binaries are placed.</summary>
-    public string TorBinaryDir { get; }
+	/// <summary>Full directory path where Tor binaries are placed.</summary>
+	public string TorBinaryDir { get; }
 
 	/// <summary>Full directory path where Tor transports plugins are placed.</summary>
 	public string TorTransportPluginsDir { get; }
@@ -97,6 +99,9 @@ public class TorSettings
 	/// <summary>Owning process ID for Tor program.</summary>
 	public int? OwningProcessId { get; }
 
+	/// <summary><c>true</c> if logging to TorLogs.txt file is enabled, <c>false</c> otherwise.</summary>
+	public bool Log { get; }
+
 	/// <summary>Full path to executable file that is used to start Tor process.</summary>
 	public string TorBinaryFilePath { get; }
 
@@ -115,7 +120,7 @@ public class TorSettings
 	private string GeoIp6Path { get; }
 
 	/// <returns>Full path to Tor binary for selected <paramref name="platform"/>.</returns>
-	public static string GetTorBinaryFilePath(string path, OSPlatform ? platform = null)
+	public static string GetTorBinaryFilePath(string path, OSPlatform? platform = null)
 	{
 		return Path.Combine(path, MicroserviceHelpers.GetFilenameWithExtension(TorBinaryFileName, platform));
 	}
@@ -146,8 +151,7 @@ public class TorSettings
 			$"--CookieAuthFile \"{CookieAuthFilePath}\"",
 			$"--DataDirectory \"{TorDataDir}\"",
 			$"--GeoIPFile \"{GeoIpPath}\"",
-			$"--GeoIPv6File \"{GeoIp6Path}\"",
-			$"--Log \"notice file {LogFilePath}\""
+			$"--GeoIPv6File \"{GeoIp6Path}\""
 		];
 
 		if (useBridges)
@@ -188,7 +192,7 @@ public class TorSettings
 				{
 					"obfs4" => "obfs4proxy",
 					"webtunnel" => "webtunnel-client",
-                    "snowflake" => "snowflake-client",
+					"snowflake" => "snowflake-client",
 					_ => throw new NotSupportedException($"Unknown Tor pluggable transport '{plugin}'."),
 				};
 
@@ -202,6 +206,11 @@ public class TorSettings
 
 				arguments.Add($"--ClientTransportPlugin \"{plugin} exec {path}\"");
 			}
+		}
+
+		if (Log)
+		{
+			arguments.Add($"--Log \"notice file {LogFilePath}\"");
 		}
 
 		if (TerminateOnExit && OwningProcessId is not null)


### PR DESCRIPTION
Contributes to #9805

This PR adds `--LogModes` command line option to specify that one wants to log to only specific logging targets[^1]. Specifically one can omit `file` to avoid storing logging data.

See also https://github.com/zkSNACKs/WalletWasabi/issues/9805#issuecomment-2071845610.

## Testing

```powershell
dotnet build && dotnet run --framework net8.0 -- --LogModes="" # Do not log at all
dotnet build && dotnet run --framework net8.0 -- --LogModes="file" # Log only to file
dotnet build && dotnet run --framework net8.0 -- --LogModes="console" # Log only to console
dotnet build && dotnet run --framework net8.0 -- --LogModes="file,console" # Log to console & file
dotnet build && dotnet run --framework net8.0 -- --LogModes="console,file" # Log to file & console (equivalent to the above line)
dotnet build && dotnet run --framework net8.0 -- --LogModes="file,file,file" # Should log once, not three times :)
dotnet build && dotnet run --framework net8.0 -- --LogModes=",,,,,," # Parsed as an empty string really
```

[^1]: `--LogTargets` might be a better name than log modes.