### PR TITLE
Median of an empty set

### DIFF
--- a/WalletWasabi.Tests/UnitTests/LinqExtensionsTests.cs
+++ b/WalletWasabi.Tests/UnitTests/LinqExtensionsTests.cs
@@ -111,7 +111,7 @@ public class LinqExtensionsTests
 	[Fact]
 	public void Median()
 	{
-		Assert.Null(Array.Empty<double>().Median());
+		Assert.Throws<ArgumentException>(() => Array.Empty<double>().Median());
 		Assert.Equal(1, new double[] { 1 }.Median());
 		Assert.Equal(2, new double[] { 1, 2 }.Median());
 		Assert.Equal(2, new double[] { 1, 2, 3 }.Median());

--- a/WalletWasabi.Tests/UnitTests/LinqExtensionsTests.cs
+++ b/WalletWasabi.Tests/UnitTests/LinqExtensionsTests.cs
@@ -107,4 +107,19 @@ public class LinqExtensionsTests
 		Assert.Equal(4, new int[] { 4, 3 }.MaxOrDefault(defaultValue: 10));
 		Assert.Equal(4, new int[] { 4 }.MaxOrDefault(defaultValue: 10));
 	}
+
+	[Fact]
+	public void Median()
+	{
+		Assert.Null(Array.Empty<double>().Median());
+		Assert.Equal(1, new double[] { 1 }.Median());
+		Assert.Equal(2, new double[] { 1, 2 }.Median());
+		Assert.Equal(2, new double[] { 1, 2, 3 }.Median());
+		Assert.Equal(3, new double[] { 1, 2, 3, 4 }.Median());
+		Assert.Equal(3, new double[] { 4, 3, 2, 1 }.Median());
+		Assert.Equal(3, new double[] { 4, 3, 2 }.Median());
+		Assert.Equal(4, new double[] { 4, 3 }.Median());
+		Assert.Equal(4, new double[] { 4 }.Median());
+		Assert.Equal(6, new double[] { 6, 6, 3 }.Median());
+	}
 }

--- a/WalletWasabi/Extensions/LinqExtensions.cs
+++ b/WalletWasabi/Extensions/LinqExtensions.cs
@@ -179,11 +179,11 @@ public static class LinqExtensions
 	public static int MaxOrDefault(this IEnumerable<int> me, int defaultValue) =>
 		me.DefaultIfEmpty(defaultValue).Max();
 
-	public static double? Median(this IEnumerable<double> me)
+	public static double Median(this IEnumerable<double> me)
 	{
 		if (!me.Any())
 		{
-			return null;
+			throw new ArgumentException("Median of an empty set is not defined.", nameof(me));
 		}
 
 		var sorted = me.Order().ToArray();

--- a/WalletWasabi/Extensions/LinqExtensions.cs
+++ b/WalletWasabi/Extensions/LinqExtensions.cs
@@ -179,13 +179,14 @@ public static class LinqExtensions
 	public static int MaxOrDefault(this IEnumerable<int> me, int defaultValue) =>
 		me.DefaultIfEmpty(defaultValue).Max();
 
-	public static double Median(this IEnumerable<double> me)
+	public static double? Median(this IEnumerable<double> me)
 	{
 		if (!me.Any())
 		{
-			return 0;
+			return null;
 		}
-		var sorted = me.OrderBy(x => x).ToArray();
+
+		var sorted = me.Order().ToArray();
 		return sorted[sorted.Length / 2];
 	}
 


### PR DESCRIPTION
AFAIK median is not defined for an empty collection. We return `0` right now.