### PR TITLE
Fix reorg error log

### DIFF
--- a/WalletWasabi/Services/SatoshiSynchronizer.cs
+++ b/WalletWasabi/Services/SatoshiSynchronizer.cs
@@ -137,7 +137,7 @@ public class SatoshiSynchronizer : BackgroundService
 						var filter = reader.ReadFilterModel();
 						if (localChain.TipHeight + 1 != filter.Header.Height)
 						{
-							Logger.LogError(ChainHeightMismatchError(filter));
+							Logger.LogDebug(ChainHeightMismatchError(filter));
 							await RewindAsync(1).ConfigureAwait(false);
 							return;
 						}

--- a/WalletWasabi/Services/SatoshiSynchronizer.cs
+++ b/WalletWasabi/Services/SatoshiSynchronizer.cs
@@ -99,7 +99,15 @@ public class SatoshiSynchronizer : BackgroundService
 		{
 			if (ws.State == WebSocketState.Open)
 			{
-				await ws.CloseAsync(WebSocketCloseStatus.NormalClosure, "Closed by client", cancellationToken).ConfigureAwait(false);
+				try
+				{
+					await ws.CloseAsync(WebSocketCloseStatus.NormalClosure, "Closed by client", cancellationToken)
+						.ConfigureAwait(false);
+				}
+				catch
+				{
+					// ignored
+				}
 			}
 		}
 

--- a/WalletWasabi/Services/SatoshiSynchronizer.cs
+++ b/WalletWasabi/Services/SatoshiSynchronizer.cs
@@ -137,7 +137,7 @@ public class SatoshiSynchronizer : BackgroundService
 						var filter = reader.ReadFilterModel();
 						if (localChain.TipHeight + 1 != filter.Header.Height)
 						{
-							Logger.LogDebug(ChainHeightMismatchError(filter));
+							Logger.LogInfo(ChainHeightMismatchError(filter));
 							await RewindAsync(1).ConfigureAwait(false);
 							return;
 						}


### PR DESCRIPTION
At the time of opening this PR several blocks were mined per second and there were many reorgs. We were logging this as errors instead of debug or info. 

Also, if there is a problem closing the websocket and exception was not caught (to ignore). 

----

Client log
```
2024-04-23 22:05:00.531 [9] ERROR       SatoshiSynchronizer.ExecuteAsync (132)  Inconsistent index state detected.
Local chain: 2642442/2642442 (0 left- best known block hash: 00000000010bddcb3516bb780c1a7657f551bea4fb331c32dcff5efaffbfbef5
Received filter: 0000000000006f85d79e128b81441b184b8af322644cefc6c8c5e1a8473bbcdb height: 2642442
```

Server log
```
2024-04-24 01:04:56.198 [25] WARNING    IndexBuilderService.Synchronize (199)   Reorg observed on the network.
2024-04-24 01:04:56.198 [25] INFO       IndexBuilderService.ReorgOneAsync (312) REORG invalid block: 00000000010bddcb3516bb780c1a7657f551bea4fb331c32dcff5efaffbfbef5
```