### PR TITLE
[Tor] Fix obfs4 transport plugin support

### DIFF
--- a/WalletWasabi/Tor/TorSettings.cs
+++ b/WalletWasabi/Tor/TorSettings.cs
@@ -190,7 +190,7 @@ public class TorSettings
 			{
 				string fileNameWithoutExtension = plugin switch
 				{
-					"obfs4" => "obfs4proxy",
+					"obfs4" => "lyrebird", // obfs4 was renamed to lyrebird.
 					"webtunnel" => "webtunnel-client",
 					"snowflake" => "snowflake-client",
 					_ => throw new NotSupportedException($"Unknown Tor pluggable transport '{plugin}'."),


### PR DESCRIPTION
Follow up to #12749

Apparently `obfs4` was [renamed](https://gitlab.torproject.org/tpo/applications/tor-browser-build/-/issues/40869) to `lyrebird`.

Addresses https://github.com/zkSNACKs/WalletWasabi/pull/12749#pullrequestreview-2020220536.

## Test

```
cd WalletWasabi.Fluent.Desktop

# 1 obfs4 bridge but it's much better to use 2 obfs4 bridges because of conflux
dotnet build && dotnet run --framework net8.0 -- --TorFolder="C:\Users\<USER>\Desktop\Tor Browser\Browser\TorBrowser\Tor" --TorBridges="obfs4 95.216.9.24:14288 2F26D43258285FEB39E4320888DFAFA8A0D20E11 cert=RJHxHEYW2JnFMTZdf2mdwpEhm7B8RQMCK6ttBL/fPhfdrF20ooAuaITK5MqZooVpXsSVVQ iat-mode=0"
```