### PR TITLE
`SpecificNodeBlockProvider`: Modify handshake warning logging

### DIFF
--- a/WalletWasabi/Wallets/SpecificNodeBlockProvider.cs
+++ b/WalletWasabi/Wallets/SpecificNodeBlockProvider.cs
@@ -166,7 +166,6 @@ public class SpecificNodeBlockProvider : IBlockProvider, IAsyncDisposable
 	}
 
 	/// <exception cref="SocketException">When connecting to the node fails.</exception>
-	/// <exception cref="OperationCanceledException">When handshake protocol with the node fails.</exception>
 	/// <exception cref="InvalidOperationException">If we are still not connected to the node after we successfully connected to it and went through a handshake.</exception>
 	internal virtual async Task<ConnectedNode> ConnectAsync(CancellationToken cancellationToken)
 	{


### PR DESCRIPTION
Fixes #11184

This PR is basically just what @turbolay suggested [here](https://github.com/zkSNACKs/WalletWasabi/issues/11184#issuecomment-2030976106).

## Testing

1. Run WW with your bitcoin node already started. No warning should be reported.
2. Run WW with your bitcoin node stopped and then start your bitcoin node. A single warning should be produced.
3. The same as 2 but start and stop your bitcoin node while WW is running.