### PR TITLE
[UI] Fix Label's ToolTip background

### DIFF
--- a/WalletWasabi.Fluent/Controls/LabelsItemsPresenter.axaml
+++ b/WalletWasabi.Fluent/Controls/LabelsItemsPresenter.axaml
@@ -66,9 +66,24 @@
                       BorderBrush="{Binding BorderBrush, RelativeSource={RelativeSource AncestorType={x:Type LabelsItemsPresenter}}}">
                 <ToolTip.Tip>
                   <Panel>
-                    <TagsBox IsReadOnly="True"
-                             Margin="4,6,0,0"
-                             Items="{Binding}" />
+                    <ItemsControl ItemsSource="{Binding}">
+                      <ItemsControl.ItemsPanel>
+                        <ItemsPanelTemplate>
+                          <WrapPanel Orientation="Horizontal" />
+                        </ItemsPanelTemplate>
+                      </ItemsControl.ItemsPanel>
+                      <ItemsControl.ItemTemplate>
+                        <DataTemplate>
+                          <TagControl Content="{Binding}">
+                            <TagControl.Styles>
+                              <Style Selector="TagControl /template/ Panel#PART_TagPanel">
+                                <Setter Property="Margin" Value="3" />
+                              </Style>
+                            </TagControl.Styles>
+                          </TagControl>
+                        </DataTemplate>
+                      </ItemsControl.ItemTemplate>
+                    </ItemsControl>
                   </Panel>
                 </ToolTip.Tip>
                 <TextBlock Text="..."


### PR DESCRIPTION
Fixed https://github.com/zkSNACKs/WalletWasabi/issues/12916

TBH `TagsBox` is a beast, and should never be used in ReadOnly mode, that's a waste of resources.