### PR TITLE
[PoC] Add resync button

### DIFF
--- a/WalletWasabi.Fluent/Models/Wallets/WalletSettingsModel.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/WalletSettingsModel.cs
@@ -91,6 +91,11 @@ public partial class WalletSettingsModel : ReactiveObject
 		return Services.WalletManager.GetWalletByName(_keyManager.WalletName).WalletId;
 	}
 
+	public void SignalResync()
+	{
+		_keyManager.SetBestHeights(0, 0);
+	}
+
 	private void SetValues()
 	{
 		_keyManager.AutoCoinJoin = AutoCoinjoin;

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Settings/WalletResyncViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Settings/WalletResyncViewModel.cs
@@ -1,0 +1,31 @@
+using System.Reactive;
+using ReactiveUI;
+using WalletWasabi.Fluent.Models.Wallets;
+using WalletWasabi.Fluent.Validation;
+using WalletWasabi.Fluent.ViewModels.Dialogs.Base;
+using WalletWasabi.Services.Terminate;
+
+namespace WalletWasabi.Fluent.ViewModels.Wallets.Settings;
+
+[NavigationMetaData(Title = "Resync Wallet", NavigationTarget = NavigationTarget.CompactDialogScreen)]
+public partial class WalletResyncViewModel : DialogViewModelBase<Unit>
+{
+	private WalletResyncViewModel(IWalletSettingsModel walletSettings)
+	{
+		SetupCancel(enableCancel: true, enableCancelOnEscape: true, enableCancelOnPressed: true);
+		NextCommand = ReactiveCommand.Create(() => OnResync(walletSettings));
+	}
+
+	private void OnResync(IWalletSettingsModel walletSettings)
+	{
+		try
+		{
+			walletSettings.SignalResync();
+			TerminateService.Instance.SignalForceTerminate();
+		}
+		catch
+		{
+			UiContext.Navigate().To().ShowErrorDialog($"Something went wrong, failed to terminate Wasabi Wallet", "Shutdown", "Cannot terminate Wasabi", NavigationTarget.CompactDialogScreen);
+		}
+	}
+}

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Settings/WalletSettingsViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Settings/WalletSettingsViewModel.cs
@@ -6,6 +6,7 @@ using WalletWasabi.Fluent.Models.UI;
 using WalletWasabi.Fluent.Infrastructure;
 using WalletWasabi.Fluent.Models.Wallets;
 using WalletWasabi.Fluent.ViewModels.Navigation;
+using System.Reactive;
 
 namespace WalletWasabi.Fluent.ViewModels.Wallets.Settings;
 
@@ -44,6 +45,7 @@ public partial class WalletSettingsViewModel : RoutableViewModel
 		NextCommand = CancelCommand;
 
 		VerifyRecoveryWordsCommand = ReactiveCommand.Create(() => Navigate().To().WalletVerifyRecoveryWords(walletModel));
+		SignalWalletResyncCommand = ReactiveCommand.Create(OnSignalResyncAsync);
 
 		this.WhenAnyValue(x => x.PreferPsbtWorkflow)
 			.Skip(1)
@@ -67,6 +69,12 @@ public partial class WalletSettingsViewModel : RoutableViewModel
 	public WalletCoinJoinSettingsViewModel WalletCoinJoinSettings { get; private set; }
 
 	public ICommand VerifyRecoveryWordsCommand { get; }
+	public ICommand SignalWalletResyncCommand { get; }
+
+	private async Task OnSignalResyncAsync()
+	{
+		await Navigate().To().WalletResync(_wallet.Settings).GetResultAsync();
+	}
 
 	private async Task OnRenameWalletAsync()
 	{

--- a/WalletWasabi.Fluent/Views/Wallets/Settings/WalletResyncView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Settings/WalletResyncView.axaml
@@ -14,7 +14,17 @@
                  Height="280" Width="450">
     <InfoMessage>
       <DockPanel>
-        <TextBlock Text="Your passphrase is also required to restore your wallet, do not forget it." />
+        <TextBlock Text="Pressing OK will shut down Wasabi." />
+      </DockPanel>
+    </InfoMessage>
+    <InfoMessage>
+      <DockPanel>
+        <TextBlock Text="Rescanning the wallet could take several hours, based on how many transactions your wallet had." />
+      </DockPanel>
+    </InfoMessage>
+    <InfoMessage>
+      <DockPanel>
+        <TextBlock Text="Do you want to continute?" />
       </DockPanel>
     </InfoMessage>
   </ContentArea>

--- a/WalletWasabi.Fluent/Views/Wallets/Settings/WalletResyncView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Settings/WalletResyncView.axaml
@@ -12,20 +12,18 @@
                  EnableCancel="{Binding EnableCancel}"
                  EnableNext="True" NextContent="Save"
                  Height="280" Width="450">
-    <InfoMessage>
-      <DockPanel>
-        <TextBlock Text="Pressing OK will shut down Wasabi." />
-      </DockPanel>
-    </InfoMessage>
-    <InfoMessage>
-      <DockPanel>
-        <TextBlock Text="Rescanning the wallet could take several hours, based on how many transactions your wallet had." />
-      </DockPanel>
-    </InfoMessage>
-    <InfoMessage>
-      <DockPanel>
-        <TextBlock Text="Do you want to continute?" />
-      </DockPanel>
-    </InfoMessage>
+    <StackPanel Spacing="20">
+      <InfoMessage>
+        <DockPanel>
+          <TextBlock Text="Pressing OK will shut down Wasabi." />
+        </DockPanel>
+      </InfoMessage>
+      <InfoMessage>
+        <DockPanel>
+          <TextBlock Text="Rescanning the wallet could take several hours, based on how many transactions your wallet had." />
+        </DockPanel>
+      </InfoMessage>
+      <TextBlock Classes="h6" Text="Do you want to continue?" />
+    </StackPanel>
   </ContentArea>
 </UserControl>

--- a/WalletWasabi.Fluent/Views/Wallets/Settings/WalletResyncView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Settings/WalletResyncView.axaml
@@ -1,0 +1,21 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:vm="clr-namespace:WalletWasabi.Fluent.ViewModels.Wallets.Settings"
+             mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
+             x:Class="WalletWasabi.Fluent.Views.Wallets.Settings.WalletResyncView"
+             x:DataType="vm:WalletResyncViewModel">
+  <ContentArea Title="{Binding Title}"
+                 Caption="Signal to rescan the wallet"
+                 EnableBack="{Binding EnableBack}"
+                 EnableCancel="{Binding EnableCancel}"
+                 EnableNext="True" NextContent="Save"
+                 Height="280" Width="450">
+    <InfoMessage>
+      <DockPanel>
+        <TextBlock Text="Your passphrase is also required to restore your wallet, do not forget it." />
+      </DockPanel>
+    </InfoMessage>
+  </ContentArea>
+</UserControl>

--- a/WalletWasabi.Fluent/Views/Wallets/Settings/WalletResyncView.axaml.cs
+++ b/WalletWasabi.Fluent/Views/Wallets/Settings/WalletResyncView.axaml.cs
@@ -1,0 +1,17 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace WalletWasabi.Fluent.Views.Wallets.Settings;
+
+public partial class WalletResyncView : UserControl
+{
+	public WalletResyncView()
+	{
+		InitializeComponent();
+	}
+
+	private void InitializeComponent()
+	{
+		AvaloniaXamlLoader.Load(this);
+	}
+}

--- a/WalletWasabi.Fluent/Views/Wallets/Settings/WalletToolsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Settings/WalletToolsView.axaml
@@ -21,5 +21,11 @@
         <TextBlock Text="Your passphrase is also required to restore your wallet, do not forget it." />
       </DockPanel>
     </InfoMessage>
+    <InfoMessage>
+      <DockPanel>
+        <Button Margin="50 0" Theme="{StaticResource AccentButton}" Command="{Binding SignalWalletResyncCommand}" Content="Resync Wallet" DockPanel.Dock="Right" />
+        <TextBlock Text="If your funds are missing, you can resynchronize wallet. Once you restart Wasabi, it can take several hours to rescan and find all your funds." />
+      </DockPanel>
+    </InfoMessage>
   </StackPanel>
 </UserControl>

--- a/WalletWasabi/Services/UpdateManager.cs
+++ b/WalletWasabi/Services/UpdateManager.cs
@@ -130,8 +130,6 @@ public class UpdateManager : IDisposable
 			{
 				EnsureToRemoveCorruptedFiles();
 
-				// This should also be done using Tor.
-				// TODO: https://github.com/zkSNACKs/WalletWasabi/issues/8800
 				// Wait a moment to avoid dossing GitHub API.
 				await Task.Delay(2000, cancellationToken).ConfigureAwait(false);
 				Logger.LogInfo($"Trying to download new version: {result.LatestVersion}");

--- a/WalletWasabi/Services/UpdateManager.cs
+++ b/WalletWasabi/Services/UpdateManager.cs
@@ -66,7 +66,7 @@ public class UpdateManager : IDisposable
 			Cleanup();
 			return;
 		}
-
+		bool readyToInstall = false;
 		if (DownloadNewVersion)
 		{
 			do
@@ -74,11 +74,10 @@ public class UpdateManager : IDisposable
 				tries++;
 				try
 				{
-					(string installerPath, Version newVersion) = await GetInstallerAsync(targetVersion, CancellationToken).ConfigureAwait(false);
+					(string installerPath, targetVersion) = await GetInstallerAsync(targetVersion, CancellationToken).ConfigureAwait(false);
 					InstallerPath = installerPath;
-					Logger.LogInfo($"Version {newVersion} downloaded successfully.");
-					updateStatus.IsReadyToInstall = true;
-					updateStatus.ClientVersion = newVersion;
+					Logger.LogInfo($"Version {targetVersion} downloaded successfully.");
+					readyToInstall = true;
 					break;
 				}
 				catch (OperationCanceledException ex)
@@ -102,8 +101,13 @@ public class UpdateManager : IDisposable
 				}
 			} while (tries < MaxTries);
 		}
-
-		UpdateAvailableToGet?.Invoke(this, updateStatus);
+		var newStatus = new UpdateStatus(updateStatus.BackendCompatible,
+			updateStatus.ClientUpToDate,
+			updateStatus.LegalDocumentsVersion,
+			updateStatus.CurrentBackendMajorVersion,
+			targetVersion)
+		{ IsReadyToInstall = readyToInstall };
+		UpdateAvailableToGet?.Invoke(this, newStatus);
 	}
 
 	/// <summary>

--- a/WalletWasabi/Services/UpdateManager.cs
+++ b/WalletWasabi/Services/UpdateManager.cs
@@ -132,6 +132,8 @@ public class UpdateManager : IDisposable
 
 				// This should also be done using Tor.
 				// TODO: https://github.com/zkSNACKs/WalletWasabi/issues/8800
+				// Wait a moment to avoid dossing GitHub API.
+				await Task.Delay(2000, cancellationToken).ConfigureAwait(false);
 				Logger.LogInfo($"Trying to download new version: {result.LatestVersion}");
 
 				// Get file stream and copy it to downloads folder to access.
@@ -235,6 +237,8 @@ public class UpdateManager : IDisposable
 
 		try
 		{
+			// Wait a moment to avoid dossing GitHub API.
+			await Task.Delay(2000, cancellationToken).ConfigureAwait(false);
 			using HttpRequestMessage sha256Request = new(HttpMethod.Get, sha256SumsUrl);
 			using HttpResponseMessage sha256Response = await HttpClient.SendAsync(sha256Request, cancellationToken).ConfigureAwait(false);
 			string sha256Content = await sha256Response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
@@ -242,6 +246,7 @@ public class UpdateManager : IDisposable
 			IoHelpers.EnsureContainingDirectoryExists(sha256SumsFilePath);
 			File.WriteAllText(sha256SumsFilePath, sha256Content);
 
+			await Task.Delay(2000, cancellationToken).ConfigureAwait(false);
 			using HttpRequestMessage signatureRequest = new(HttpMethod.Get, wasabiSigUrl);
 			using HttpResponseMessage signatureResponse = await HttpClient.SendAsync(signatureRequest, cancellationToken).ConfigureAwait(false);
 			string signatureContent = await signatureResponse.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);


### PR DESCRIPTION
Fixes https://github.com/zkSNACKs/WalletWasabi/issues/2005

Now the user can press the Resync button under `Wallet Settings` -> `Tools`.
It will open a dialog, and if OK is pressed, the `Height` and `TurboSyncHeight` will be set to 0, and the wallet will shut down.

Calling `ForceTerminate` is needed because the open dialog won't let Wasabi to terminate the simple way.
This means that if coinjoin is in critical state, we will terminate whatsoever. This should be changed.