### PR TITLE
Reverts #12964 + Fix PF's CTS dispose

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Login/PasswordFinder/SearchPasswordViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Login/PasswordFinder/SearchPasswordViewModel.cs
@@ -43,9 +43,13 @@ public partial class SearchPasswordViewModel : RoutableViewModel
 			.Subscribe()
 			.DisposeWith(disposables);
 
-		var findPasswordTask = FindPasswordAsync();
+		var t = FindPasswordAsync();
 
-		Disposable.Create(async () => await findPasswordTask)
+		Disposable.Create(
+				async () =>
+				{
+					await t;
+				})
 			.DisposeWith(disposables);
 	}
 

--- a/WalletWasabi.Fluent/ViewModels/Login/PasswordFinder/SearchPasswordViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Login/PasswordFinder/SearchPasswordViewModel.cs
@@ -38,8 +38,7 @@ public partial class SearchPasswordViewModel : RoutableViewModel
 	{
 		base.OnNavigatedTo(isInHistory, disposables);
 
-		var cts = new CancellationTokenSource()
-			.DisposeWith(disposables);
+		var cts = new CancellationTokenSource();
 
 		_model.Progress
 			.Do(t => SetStatus(t.Percentage, t.RemainingTime))
@@ -55,6 +54,8 @@ public partial class SearchPasswordViewModel : RoutableViewModel
 					await t;
 				})
 			.DisposeWith(disposables);
+
+		disposables.Add(cts);
 	}
 
 	private async Task FindPasswordAsync(CancellationToken token)


### PR DESCRIPTION
No idea why this works.

To repro simply try to open a wallet without password by writing "f" in passphrase field then click "forgot passphrase" then write f, f, press no, no, and wait for crash.

The only change of this PR is to change

`var cts = new CancellationTokenSource().DisposeWith(disposables);`

to

```
var cts = new CancellationTokenSource()
[...]
disposables.Add(cts);
```