### PR TITLE
`TerminateService`: Allow forceful termination on second CTLR+C

### DIFF
--- a/WalletWasabi/Services/Terminate/TerminateService.cs
+++ b/WalletWasabi/Services/Terminate/TerminateService.cs
@@ -100,13 +100,21 @@ public class TerminateService
 
 	private void Console_CancelKeyPress(object? sender, ConsoleCancelEventArgs e)
 	{
-		Logger.LogWarning($"Process termination was requested using '{e.SpecialKey}' keyboard shortcut.");
+		if (ForcefulTerminationRequested.Task.IsCompleted)
+		{
+			Logger.LogWarning("Multiple requests to terminate registered. Stopping the application non-gracefully.");
+			e.Cancel = false;
+		}
+		else
+		{
+			Logger.LogWarning($"Process termination was requested using '{e.SpecialKey}' keyboard shortcut.");
 
-		// Do not kill the process ...
-		e.Cancel = true;
+			// Do not kill the process ...
+			e.Cancel = true;
 
-		// ... instead signal back that the app should terminate.
-		SignalForceTerminate();
+			// ... instead signal back that the app should terminate.
+			SignalForceTerminate();
+		}
 	}
 
 	public void SignalGracefulCrash(Exception ex)


### PR DESCRIPTION
This PR is a sort of ultimate solution for CTRL+C issues. 

Right now, I suspect that that `CoinJoinManager` does not respond to CTRL+C requests correctly because I can see in my logs

```log
2024-05-04 12:52:16.102 [15] WARNING	TerminateService.Console_CancelKeyPress (103)	Process termination was requested using 'ControlC' keyboard shortcut.
2024-05-04 12:52:45.155 [41] INFO	CoinJoinClient.StartRoundAsync (299)	Round (XY): Aborted. Not enough participants.
2024-05-04 12:52:46.133 [56] INFO	CoinJoinManager.HandleCoinJoinFinalizationAsync (511)	Wallet (2022-10): CoinJoinClient finished. Coinjoin transaction was not broadcast.
2024-05-04 12:52:46.134 [56] INFO	CoinJoinManager.HandleCoinJoinFinalizationAsync (605)	Wallet (2022-10): CoinJoinClient restart automatically.
2024-05-04 12:53:43.604 [27] INFO	HybridFeeProvider.OnAllFeeEstimateArrived (106)	Fee rates are acquired from WasabiSynchronizer ranging from target 2 blocks at 30 sat/vByte to target 1008 blocks at 12 sat/vByte.
2024-05-04 12:54:44.765 [41] INFO	HybridFeeProvider.OnAllFeeEstimateArrived (106)	Fee rates are acquired from WasabiSynchronizer ranging from target 2 blocks at 40 sat/vByte to target 1008 blocks at 12 sat/vByte.
```

But perhaps it's a feature, I'm not sure. Be it as it may, when user wants to kill the application, this PR should help because first CTRL+C leads to a graceful shutdown request but the second should kill the application which I feel is better than:

```log
2024-05-04 12:46:30.646 [19] WARNING	TerminateService.Console_CancelKeyPress (103)	Process termination was requested using 'ControlC' keyboard shortcut.
2024-05-04 12:46:31.948 [20] WARNING	TerminateService.Console_CancelKeyPress (103)	Process termination was requested using 'ControlC' keyboard shortcut.
2024-05-04 12:46:32.156 [38] WARNING	TerminateService.Console_CancelKeyPress (103)	Process termination was requested using 'ControlC' keyboard shortcut.
2024-05-04 12:51:30.027 [25] WARNING	TerminateService.Console_CancelKeyPress (103)	Process termination was requested using 'ControlC' keyboard shortcut.
2024-05-04 12:52:16.102 [15] WARNING	TerminateService.Console_CancelKeyPress (103)	Process termination was requested using 'ControlC' keyboard shortcut.
```

## How to test

Scenario 1

1. Run WW
2. Press CTRL+C (graceful shutdown is expected and app should, typically, slowly shut down)

Scenario 2

1. Run WW
2. Press CTRL+C twice (app should terminate almost immediately)