### PR TITLE
[Tor] Towards Whonix & Tails

### DIFF
--- a/WalletWasabi.Daemon/Config.cs
+++ b/WalletWasabi.Daemon/Config.cs
@@ -59,6 +59,9 @@ public class Config
 			[ nameof(UseTor)] = (
 				"All the communications go through the Tor network",
 				GetBoolValue("UseTor", PersistentConfig.UseTor, cliArgs)),
+			[ nameof(UseOnlyRunningTor)] = (
+				"Connect to an already running Tor instance without attempting to run the bundled Tor",
+				GetBoolValue("UseOnlyRunningTor", false, cliArgs)),
 			[ nameof(TorFolder)] = (
 				"Folder where Tor binary is located",
 				GetNullableStringValue("TorFolder", null, cliArgs)),
@@ -155,6 +158,7 @@ public class Config
 	public string? TestNetCoordinatorUri => GetEffectiveValue<NullableStringValue, string?>(nameof(TestNetCoordinatorUri));
 	public string? RegTestCoordinatorUri => GetEffectiveValue<NullableStringValue, string?>(nameof(RegTestCoordinatorUri));
 	public bool UseTor => GetEffectiveValue<BoolValue, bool>(nameof(UseTor)) && Network != Network.RegTest;
+	public bool UseOnlyRunningTor => GetEffectiveValue<BoolValue, bool>(nameof(UseOnlyRunningTor));
 	public string? TorFolder => GetEffectiveValue<NullableStringValue, string?>(nameof(TorFolder));
 	public int TorSocksPort => GetEffectiveValue<IntValue, int>(nameof(TorSocksPort));
 	public int TorControlPort => GetEffectiveValue<IntValue, int>(nameof(TorControlPort));

--- a/WalletWasabi.Tests/UnitTests/Tor/Socks5/Pool/TorHttpPoolTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Tor/Socks5/Pool/TorHttpPoolTests.cs
@@ -45,7 +45,7 @@ public class TorHttpPoolTests
 		TorTcpConnectionFactory tcpConnectionFactory = mockTcpConnectionFactory.Object;
 
 		// Use implementation of TorHttpPool and only replace SendCoreAsync behavior.
-		Mock<TorHttpPool> mockTorHttpPool = new(MockBehavior.Loose, tcpConnectionFactory) { CallBase = true };
+		Mock<TorHttpPool> mockTorHttpPool = new(MockBehavior.Loose, tcpConnectionFactory, true) { CallBase = true };
 		mockTorHttpPool.Setup(x => x.SendCoreAsync(It.IsAny<TorTcpConnection>(), It.IsAny<HttpRequestMessage>(), It.IsAny<Uri>(), It.IsAny<CancellationToken>()))
 			.Returns((TorTcpConnection tcpConnection, HttpRequestMessage request, Uri requestUriOverride, CancellationToken cancellationToken) =>
 			{
@@ -373,7 +373,7 @@ public class TorHttpPoolTests
 		Mock<TorTcpConnectionFactory> mockTcpConnectionFactory = new(MockBehavior.Strict, new IPEndPoint(IPAddress.Loopback, 7777));
 		mockTcpConnectionFactory.Setup(c => c.ConnectAsync(It.IsAny<Uri>(), aliceCircuit, It.IsAny<CancellationToken>())).ReturnsAsync(aliceConnection);
 
-		Mock<TorHttpPool> mockTorHttpPool = new(MockBehavior.Loose, mockTcpConnectionFactory.Object) { CallBase = true };
+		Mock<TorHttpPool> mockTorHttpPool = new(MockBehavior.Loose, mockTcpConnectionFactory.Object, true) { CallBase = true };
 		mockTorHttpPool.Setup(x => x.SendCoreAsync(It.IsAny<TorTcpConnection>(), It.IsAny<HttpRequestMessage>(), It.IsAny<Uri>(), It.IsAny<CancellationToken>()))
 			.Returns((TorTcpConnection tcpConnection, HttpRequestMessage request, Uri requestUriOverride, CancellationToken cancellationToken) =>
 			{

--- a/WalletWasabi/Tor/TorMonitor.cs
+++ b/WalletWasabi/Tor/TorMonitor.cs
@@ -23,6 +23,7 @@ using WalletWasabi.WebClients.Wasabi;
 namespace WalletWasabi.Tor;
 
 /// <summary>Monitors Tor process bootstrap and reachability of Wasabi Backend.</summary>
+/// <remarks>Tor Monitor can only work if Tor Control is available.</remarks>
 public class TorMonitor : PeriodicRunner
 {
 	public static readonly TimeSpan CheckIfRunningAfterTorMisbehavedFor = TimeSpan.FromMinutes(10);
@@ -107,7 +108,7 @@ public class TorMonitor : PeriodicRunner
 			using CancellationTokenSource linkedCts2 = CancellationTokenSource.CreateLinkedTokenSource(linkedCts.Token, torTerminatedCancellationToken);
 
 			Logger.LogInfo("Starting Tor bootstrap monitor…");
-			await torControlClient.SubscribeEventsAsync(EventNames, linkedCts2.Token).ConfigureAwait(false);
+			await torControlClient!.SubscribeEventsAsync(EventNames, linkedCts2.Token).ConfigureAwait(false);
 			bool circuitEstablished = false;
 
 			await foreach (TorControlReply reply in torControlClient.ReadEventsAsync(linkedCts2.Token).ConfigureAwait(false))

--- a/WalletWasabi/Tor/TorSettings.cs
+++ b/WalletWasabi/Tor/TorSettings.cs
@@ -27,6 +27,7 @@ public class TorSettings
 		string dataDir,
 		string distributionFolderPath,
 		bool terminateOnExit,
+		bool useOnlyRunningTor = false,
 		int socksPort = DefaultSocksPort,
 		int controlPort = DefaultControlPort,
 		string? torFolder = null,
@@ -62,11 +63,22 @@ public class TorSettings
 		LogFilePath = Path.Combine(dataDir, "TorLogs.txt");
 		IoHelpers.EnsureContainingDirectoryExists(LogFilePath);
 		DistributionFolder = distributionFolderPath;
-		TerminateOnExit = terminateOnExit;
+
+		if (useOnlyRunningTor && terminateOnExit)
+		{
+			Logger.LogWarning("Wasabi is instructed to use a running Tor process. Terminate on exit was disabled.");
+		}
+
+		UseOnlyRunningTor = useOnlyRunningTor; 
+		TerminateOnExit = useOnlyRunningTor ? false : terminateOnExit;
+
 		Log = log;
 		GeoIpPath = Path.Combine(DistributionFolder, "Tor", "Geoip", "geoip");
 		GeoIp6Path = Path.Combine(DistributionFolder, "Tor", "Geoip", "geoip6");
 	}
+
+	/// <summary><c>true</c> if Wasabi should not attempt to run any Tor process (bundled) or specified via <c>--TorFolder</c> command line option.</summary>
+	public bool UseOnlyRunningTor { get; }
 
 	/// <summary><c>true</c> if user specified a custom Tor folder to run a (possibly) different Tor binary than the bundled Tor, <c>false</c> otherwise.</summary>
 	public bool IsCustomTorFolder { get; }

--- a/WalletWasabi/WebClients/Wasabi/WasabiHttpClientFactory.cs
+++ b/WalletWasabi/WebClients/Wasabi/WasabiHttpClientFactory.cs
@@ -17,7 +17,7 @@ public class WasabiHttpClientFactory : IWasabiHttpClientFactory, IAsyncDisposabl
 	/// Creates a new instance of the object.
 	/// </summary>
 	/// <param name="torEndPoint">If <c>null</c> then clearnet (not over Tor) is used, otherwise HTTP requests are routed through provided Tor endpoint.</param>
-	public WasabiHttpClientFactory(EndPoint? torEndPoint, Func<Uri>? backendUriGetter)
+	public WasabiHttpClientFactory(EndPoint? torEndPoint, Func<Uri>? backendUriGetter, bool torControlAvailable = true)
 	{
 		HttpClient = CreateLongLivedHttpClient(automaticDecompression: DecompressionMethods.GZip | DecompressionMethods.Brotli);
 
@@ -27,7 +27,7 @@ public class WasabiHttpClientFactory : IWasabiHttpClientFactory, IAsyncDisposabl
 		// Connecting to loopback's URIs cannot be done via Tor.
 		if (TorEndpoint is { } && (BackendUriGetter is null || !BackendUriGetter().IsLoopback))
 		{
-			TorHttpPool = new(TorEndpoint);
+			TorHttpPool = new(TorEndpoint, torControlAvailable);
 			BackendHttpClient = new TorHttpClient(BackendUriGetter, TorHttpPool, Mode.DefaultCircuit);
 		}
 		else


### PR DESCRIPTION
Contributes to #12848

This PR adds `--UseOnlyRunningTor` command line option and its purpose is to use only a pre-running Tor instance to which we can connect. The purpose is then:

* WW2 should be compatible with Whonix or Tails[^1] then because it is not possible to spin up a new Tor instance in these distributions because Tor-over-Tor problem would occur.
* To facilitate this, `--UseOnlyRunningTor` does *not* rely on Tor control port[^2]. 

### How to test

On `master` branch, start WW, disable "terminate Tor on exit" in settings, start WW again and turn it off -> you should have a Tor process running on port 37150

On the PR's branch, connect to TorSocksPort=37150 and set a made up port for TorControlPort to make sure it CANNOT be used.

```bash
dotnet build && dotnet run --framework net8.0 -- --TorSocksPort=37150 --TorControlPort=63999 --UseOnlyRunningTor=true
```

You should be able to do a coinjoin or just use your wallet normally without a hiccup.


[^1]: That was a goal for a long time.
[^2]: It seems it works but the cost is that we do not use `TorMonitor`.