### PR TITLE
[UI] Add Wallet - remove oobe backgroud

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/AddWallet/AddWalletPageViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/AddWallet/AddWalletPageViewModel.cs
@@ -105,8 +105,6 @@ public partial class AddWalletPageViewModel : DialogViewModelBase<Unit>
 
 	public async Task Activate()
 	{
-		MainViewModel.Instance.IsOobeBackgroundVisible = true;
 		await NavigateDialogAsync(this, NavigationTarget.DialogScreen);
-		MainViewModel.Instance.IsOobeBackgroundVisible = false;
 	}
 }


### PR DESCRIPTION
Closes https://github.com/zkSNACKs/WalletWasabi/issues/12715

This PR only removed the BG when adding a wallet. For welcome screens (and for the first wallet) it still be there as it has two purposes:

- The wallet list is empty, there is nothing to show in the background, and it looks odd.
- Make the initial experience more engaging and memorable for first-time users.