### PR TITLE
CS8600 removal

### DIFF
--- a/WalletWasabi.Fluent/Controls/CurrencyEntryBox.axaml.cs
+++ b/WalletWasabi.Fluent/Controls/CurrencyEntryBox.axaml.cs
@@ -373,11 +373,11 @@ public partial class CurrencyEntryBox : TextBox
 	// Pre-composes the TextInputEventArgs to see the potential Text that is to
 	// be committed to the TextPresenter in this control.
 
-	private string? RemoveInvalidCharacters(string? text)
+	private string RemoveInvalidCharacters(string? text)
 	{
 		if (text is null)
 		{
-			return null;
+			return "";
 		}
 
 		for (var i = 0; i < InvalidCharacters.Length; i++)


### PR DESCRIPTION
https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/compiler-messages/nullable-warnings?f1url=%3FappId%3Droslyn%26k%3Dk(CS8600)

Converting null literal or possible null value to non-nullable type.

We can safely change the return value to string since the only caller just uses IsNullOrEmpty, don't differentiate between the two state (null vs empty string).