### PR TITLE
[trivial] Warn about CA1865-CA1867: Use 'string.Method(char)' instead of 'strin…

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -300,6 +300,11 @@ dotnet_diagnostic.CA1847.severity = warning
 # CA1859: Use concrete types when possible for improved performance
 dotnet_diagnostic.CA1859.severity = none
 
+# CA1865-CA1867: Use 'string.Method(char)' instead of 'string.Method(string)' for string with single char
+dotnet_diagnostic.CA1865.severity = warning
+dotnet_diagnostic.CA1866.severity = warning
+dotnet_diagnostic.CA1867.severity = warning
+
 # CA1868: Unnecessary call to Set.Contains(item)
 dotnet_diagnostic.CA1868.severity = warning
 

--- a/WalletWasabi.Fluent/Controls/CurrencyEntryBox.axaml.cs
+++ b/WalletWasabi.Fluent/Controls/CurrencyEntryBox.axaml.cs
@@ -181,12 +181,12 @@ public partial class CurrencyEntryBox : TextBox
 
 	private bool IsReplacingWithImplicitDecimal(string input)
 	{
-		return input.StartsWith(".") && SelectedText == Text;
+		return input.StartsWith('.') && SelectedText == Text;
 	}
 
 	private bool IsInsertingImplicitDecimal(string input)
 	{
-		return input.StartsWith(".") && CaretIndex == 0 && Text is not null && !Text.Contains('.');
+		return input.StartsWith('.') && CaretIndex == 0 && Text is not null && !Text.Contains('.');
 	}
 
 	private TextInputEventArgs ReplaceCurrentTextWithLeadingZero(TextInputEventArgs e)

--- a/WalletWasabi/Blockchain/Keys/WalletGenerator.cs
+++ b/WalletWasabi/Blockchain/Keys/WalletGenerator.cs
@@ -64,7 +64,7 @@ public class WalletGenerator
 			return false;
 		}
 		var invalidChars = Path.GetInvalidFileNameChars();
-		var isValid = !walletName.Any(c => invalidChars.Contains(c)) && !walletName.EndsWith(".");
+		var isValid = !walletName.Any(c => invalidChars.Contains(c)) && !walletName.EndsWith('.');
 		var isReserved = ReservedFileNames.Any(w => walletName.ToUpper() == w || walletName.ToUpper().StartsWith(w + "."));
 		return isValid && !isReserved;
 	}

--- a/WalletWasabi/Helpers/EnvironmentHelpers.cs
+++ b/WalletWasabi/Helpers/EnvironmentHelpers.cs
@@ -121,10 +121,10 @@ public static class EnvironmentHelpers
 	// the whole string is the file name.
 	public static string ExtractFileName(string callerFilePath)
 	{
-		var lastSeparatorIndex = callerFilePath.LastIndexOf("\\");
+		var lastSeparatorIndex = callerFilePath.LastIndexOf('\\');
 		if (lastSeparatorIndex == -1)
 		{
-			lastSeparatorIndex = callerFilePath.LastIndexOf("/");
+			lastSeparatorIndex = callerFilePath.LastIndexOf('/');
 		}
 
 		var fileName = callerFilePath;

--- a/WalletWasabi/Tor/Control/Messages/CircuitStatus/CircuitInfo.cs
+++ b/WalletWasabi/Tor/Control/Messages/CircuitStatus/CircuitInfo.cs
@@ -67,7 +67,7 @@ public record CircuitInfo
 		while (remainder != "")
 		{
 			// Read <PATH>.
-			if (remainder.StartsWith("$", StringComparison.Ordinal))
+			if (remainder.StartsWith('$'))
 			{
 				string pathVal;
 				(pathVal, remainder) = Tokenizer.ReadUntilSeparator(remainder);

--- a/WalletWasabi/Userfacing/CurrencyInput.cs
+++ b/WalletWasabi/Userfacing/CurrencyInput.cs
@@ -50,7 +50,7 @@ public static partial class CurrencyInput
 		}
 
 		// Trim starting zeros.
-		if (corrected.StartsWith("0"))
+		if (corrected.StartsWith('0'))
 		{
 			// If zeroless starts with a dot, then leave a zero.
 			// Else trim all the zeros.


### PR DESCRIPTION
…g.Method(string)' for string with single char

See https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/quality-rules/ca1865-ca1867

This PR unifies our rules with rules of Code Factor (https://www.codefactor.io/repository/github/zksnacks/walletwasabi/pull/12986) and unblocks #12986.