### PR TITLE
[config] It should be possible to modify settings in UI when `--LogLevel` is set

### DIFF
--- a/WalletWasabi.Daemon/Config.cs
+++ b/WalletWasabi.Daemon/Config.cs
@@ -193,7 +193,7 @@ public class Config
 
 	/// <summary>Whether a config option was overridden by a command line argument or an environment variable.</summary>
 	/// <remarks>
-	/// Changing config options in the UI while a config option is overridden would bring uncertainty if user understands consequences,
+	/// Changing config options in the UI while a config option is overridden would bring uncertainty if user understands consequences or not,
 	/// thus it is normally not allowed. However, there are exceptions as what options are taken into account, there is currently
 	/// one exception: <see cref="LogLevel"/>.
 	/// </remarks>


### PR DESCRIPTION
This PR makes sure that one can modify settings even though `--LogLevel` option is overriden.

I created this PR because I find the master's behavior annoying.

## How to test

Run the following command on `master` and on this PR's branch:

```bash
cd WalletWasabi.Fluent.Desktop
dotnet build && dotnet run --framework net8.0 -- --LogLevel=trace
```

On `master`, UI settings are read-only, on this branch settings are modifiable.