### PR TITLE
[DEBUG] Remove cache usage in output-registration

### DIFF
--- a/WalletWasabi.Backend/Controllers/WabiSabiController.cs
+++ b/WalletWasabi.Backend/Controllers/WabiSabiController.cs
@@ -71,7 +71,7 @@ public class WabiSabiController : ControllerBase, IWabiSabiApiRequestHandler
 		using CancellationTokenSource timeoutCts = new(RequestTimeout);
 		using CancellationTokenSource linkedCts = CancellationTokenSource.CreateLinkedTokenSource(timeoutCts.Token, cancellationToken);
 
-		await IdempotencyRequestCache.GetCachedResponseAsync(request, action: Arena.RegisterOutputCoreAsync, linkedCts.Token);
+		await Arena.RegisterOutputCoreAsync(request, linkedCts.Token);
 	}
 
 	[HttpPost("credential-issuance")]


### PR DESCRIPTION
This PR removes the usage of the `IdempotencyCache` in `output-registration` endpoint in an effort to find the cause of #12856 

The point is to deploy to testnet to see if problem is still reproducible without the cache usage.