### PR TITLE
Improve output registration error handling

### DIFF
--- a/WalletWasabi.Fluent/Models/Wallets/WalletRepository.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/WalletRepository.cs
@@ -30,8 +30,8 @@ public partial class WalletRepository : ReactiveObject
 
 		var signals =
 			Observable.FromEventPattern<Wallet>(Services.WalletManager, nameof(WalletManager.WalletAdded))
-					  .Select(_ => Unit.Default)
-					  .StartWith(Unit.Default);
+					  .Select(_ => System.Reactive.Unit.Default)
+					  .StartWith(System.Reactive.Unit.Default);
 
 		Wallets =
 			signals.Fetch(() => Services.WalletManager.GetWallets(), x => x.WalletId)

--- a/WalletWasabi.Fluent/ViewModels/Dialogs/AboutAdvancedInfoViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Dialogs/AboutAdvancedInfoViewModel.cs
@@ -1,4 +1,3 @@
-using System.Reactive;
 using WalletWasabi.Fluent.ViewModels.Dialogs.Base;
 using WalletWasabi.Helpers;
 using WalletWasabi.WebClients.Wasabi;
@@ -6,7 +5,7 @@ using WalletWasabi.WebClients.Wasabi;
 namespace WalletWasabi.Fluent.ViewModels.Dialogs;
 
 [NavigationMetaData(Title = "About", NavigationTarget = NavigationTarget.CompactDialogScreen)]
-public partial class AboutAdvancedInfoViewModel : DialogViewModelBase<Unit>
+public partial class AboutAdvancedInfoViewModel : DialogViewModelBase<System.Reactive.Unit>
 {
 	public AboutAdvancedInfoViewModel()
 	{

--- a/WalletWasabi.Tests/UnitTests/Helpers/ResultTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Helpers/ResultTests.cs
@@ -1,0 +1,54 @@
+using System.Linq;
+using WalletWasabi.Helpers;
+using Xunit;
+
+namespace WalletWasabi.Tests.UnitTests.Helpers;
+
+using ParsingResult = Result<int, string>;
+public class ResultTests
+{
+	private ParsingResult ParseInt(string s) =>
+		int.TryParse(s, out var n)
+			? n
+			: $"{s} is not a number";
+
+	[Fact]
+	public void SimpleResultTests()
+	{
+		// Simple results
+		// "1" -> Ok 1
+		// "Maria" -> Fail "Maria is not a number"
+		Assert.Equal(ParsingResult.Ok(1), ParseInt("1"));
+		Assert.Equal(ParsingResult.Fail("Maria is not a number"), ParseInt("Maria"));
+
+		// ["1", "2", "3"] -> Ok [1, 2, 3]
+		new[] { "1", "2", "3" }
+			.Select(ParseInt)
+			.SequenceResults()
+			.MatchDo(
+				vs => Assert.Equal(new[]{1,2,3}, vs),
+				_ => Assert.Fail("All numbers are correct and it shouldn't have failed."));
+
+		// ["Maria", "Julio"] -> Fail ["Maria is not a number", "Julio is not a number"]
+		new[] { "Maria", "Julio" }
+			.Select(ParseInt)
+			.SequenceResults()
+			.MatchDo(
+				_ => Assert.Fail("There are no valid integers, this should have failed."),
+				e => Assert.Equal(new [] {"Maria is not a number", "Julio is not a number"}, e));
+
+		// [Ok "1", Fail "Maria", Ok -7] -> Fail ["Maria is not a number"]
+		new [] { ParseInt("1"), ParseInt("Maria"), ParseInt("-7") }
+			.SequenceResults()
+			.MatchDo(
+				_ => Assert.Fail("There are non-integer values, this should have failed."),
+				e => Assert.Equal(new [] {"Maria is not a number"}, e));
+
+		// [Ok "1", Ok -7, Fail "Julio", Fail "Maria",] -> Fail ["Julio is not a number", "Maria is not a number"]
+		new [] { ParseInt("1"),  ParseInt("-7"), ParseInt("Julio"), ParseInt("Maria") }
+			.SequenceResults()
+			.MatchDo(
+				_ => Assert.Fail("There are non-integer values, this should have failed."),
+				e => Assert.Equal(new [] {"Julio is not a number", "Maria is not a number"}, e));
+	}
+}

--- a/WalletWasabi/Helpers/Result.cs
+++ b/WalletWasabi/Helpers/Result.cs
@@ -1,0 +1,104 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace WalletWasabi.Helpers;
+
+public record Unit
+{
+	public static readonly Unit Instance = new();
+}
+
+public record Result<TValue,TError>
+{
+	private readonly TValue? _value;
+	private readonly TError? _error;
+
+	private readonly bool _isSuccess;
+
+	protected Result(TValue value)
+	{
+		_isSuccess = true;
+		_value = value;
+		_error = default;
+	}
+
+	protected Result(TError error)
+	{
+		_isSuccess = false;
+		_value = default;
+		_error = error;
+	}
+
+	public static Result<TValue, TError> Ok(TValue value) => value;
+	public static Result<TValue, TError> Fail(TError error) => error;
+	public static implicit operator Result<TValue, TError>(TValue value) => new(value);
+	public static implicit operator Result<TValue, TError> (TError error) => new(error);
+
+	public delegate T SuccessAction<out T>(TValue s);
+	public delegate T FailureAction<out T>(TError e);
+
+	public T Match<T>(SuccessAction<T> success, FailureAction<T> failure) =>
+		_isSuccess
+			? success(_value!)
+			: failure(_error!);
+
+	public void MatchDo(Action<TValue> success, Action<TError> failure)
+	{
+		if (_isSuccess)
+		{
+			success(_value!);
+		}
+		else
+		{
+			failure(_error!);
+		}
+	}
+
+	public Result<T, TError> Then<T>(Func<TValue, T> f) =>
+		Match(v => Result<T, TError>.Ok(f(v)), e => e);
+
+	public static Result<TValue[], TError[]> Sequence(IEnumerable<Result<TValue, TError>> results)
+	{
+		Result<TValue[], TError[]> initialState = Array.Empty<TValue>();
+
+		return results.Aggregate(initialState, (acc, s) =>
+			(acc._isSuccess, s._isSuccess) switch
+			{
+				(true, true) => acc._value!.Append(s._value!).ToArray(),
+				(true, false) => new[] {s._error!},
+				(false, true) => acc._error!,
+				(false, false) => acc._error!.Append(s._error!).ToArray()
+			});
+	}
+}
+
+public record Result<TError> : Result<Unit, TError>
+{
+	private Result(Unit value) : base(value)
+	{
+	}
+
+	private Result(TError error) : base(error)
+	{
+	}
+
+	public static implicit operator Result<TError> (TError error) => new(error);
+	public static Result<TError> Ok() => new(Unit.Instance);
+	public static Result<TError> Fail(TError error) => new(error);
+
+	public static Result<TError[]> Sequence(IEnumerable<Result<TError>> results) =>
+		Result<Unit, TError>.Sequence(results)
+			.Match(
+				_ => Result<TError[]>.Ok(),
+				es => Result<TError[]>.Fail(es));
+}
+
+public static class ResultExtensions
+{
+	public static Result<TValue[], TError[]>
+		SequenceResults<TValue, TError>(this IEnumerable<Result<TValue, TError>> results) =>
+		Result<TValue, TError>.Sequence(results);
+
+	public static Result<TError[]> SequenceResults<TError>(this IEnumerable<Result<TError>> results) =>
+		Result<TError>.Sequence(results);
+}

--- a/WalletWasabi/WabiSabi/Client/CoinJoin/Client/DependencyGraphTaskScheduler.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoin/Client/DependencyGraphTaskScheduler.cs
@@ -5,9 +5,12 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using WabiSabi.Crypto.ZeroKnowledge;
+using WalletWasabi.Affiliation.Models;
 using WalletWasabi.Blockchain.Keys;
 using WalletWasabi.Crypto;
+using WalletWasabi.Helpers;
 using WalletWasabi.Logging;
+using WalletWasabi.Userfacing.Bip21;
 using WalletWasabi.WabiSabi.Backend.Models;
 using WalletWasabi.WabiSabi.Client.CredentialDependencies;
 
@@ -149,7 +152,12 @@ public class DependencyGraphTaskScheduler
 		}
 	}
 
-	public async Task StartOutputRegistrationsAsync(IEnumerable<TxOut> txOuts, BobClient bobClient,IDestinationProvider destinationProvider, ImmutableList<DateTimeOffset> outputRegistrationScheduledDates, CancellationToken cancellationToken)
+	public record OutputRegistrationError();
+	public record UnknownError(Script ScriptPubKey) : OutputRegistrationError;
+	public record AlreadyRegisteredScriptError(Script ScriptPubKey) : OutputRegistrationError;
+
+	public async Task<Result<OutputRegistrationError[]>> StartOutputRegistrationsAsync(IEnumerable<TxOut> txOuts, BobClient bobClient,
+		ImmutableList<DateTimeOffset> outputRegistrationScheduledDates, CancellationToken cancellationToken)
 	{
 		using CancellationTokenSource ctsOnError = new();
 		using CancellationTokenSource linkedCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken, ctsOnError.Token);
@@ -180,20 +188,23 @@ public class DependencyGraphTaskScheduler
 						await Task.Delay(delay, cancellationToken).ConfigureAwait(false);
 					}
 					await smartRequestNode.StartOutputRegistrationAsync(bobClient, txOut.ScriptPubKey, cancellationToken).ConfigureAwait(false);
+					return Result<OutputRegistrationError>.Ok();
 				}
 				catch (WabiSabiProtocolException ex) when (ex.ErrorCode == WabiSabiProtocolErrorCode.AlreadyRegisteredScript)
 				{
 					Logger.LogDebug($"Output registration error, code:'{ex.ErrorCode}' message:'{ex.Message}'.");
-					destinationProvider.TrySetScriptStates(KeyState.Used, new[] { txOut.ScriptPubKey });
+					return new AlreadyRegisteredScriptError(txOut.ScriptPubKey);
 				}
 				catch (Exception ex)
 				{
 					Logger.LogInfo($"Output registration error message:'{ex.Message}'.");
+					return new UnknownError(txOut.ScriptPubKey);
 				}
 			})
 			.ToImmutableArray();
 
 		await Task.WhenAll(tasks).ConfigureAwait(false);
+		return tasks.Select(x => x.Result).SequenceResults();
 	}
 
 	private IEnumerable<(AliceClient AliceClient, InputNode Node)> PairAliceClientAndRequestNodes(IEnumerable<AliceClient> aliceClients, DependencyGraph graph)


### PR DESCRIPTION
This PR is an attempt to improve situations that lead to bad designs. For example, the `StartOutputRegistrationsAsync` receives the list of outputs that it has to register, the schedule that has to use for the registration and the bob client to perform the operation. However, it also received a `DestinationProvider`! WFT!? The destination provider provides destinations, it already provided those destinations which were passed to the `StartOutputRegistrationsAsync` method. Or well you want a meal or a well you want a chef but for the sake of gosh don't bring me the food AND the chef who cooked that meal!

This happens because we create functions that return nothing to the caller and for that reason the callee has to do it all and needs to receive dependencies from the caller to do things that the caller should do. This is never good because the callee doesn't have enough context to solve all the situations, upper a function is in the call stack, more context they have.

This PR adds a simple/simplistic `Result` type to handle situations like the one described above. 