### PR TITLE
[refactoring] `CoinJoinProcessor`: pass correctly `WasabiHttpClientFactory`

### DIFF
--- a/WalletWasabi.Daemon/Global.cs
+++ b/WalletWasabi.Daemon/Global.cs
@@ -251,7 +251,7 @@ public class Global
 				Logger.LogInfo("Start synchronizing filters...");
 
 				TransactionBroadcaster.Initialize(HostedServices.Get<P2pNetwork>().Nodes, BitcoinCoreNode?.RpcClient);
-				CoinJoinProcessor = new CoinJoinProcessor(Network, HostedServices.Get<WasabiSynchronizer>(), WalletManager, BitcoinCoreNode?.RpcClient);
+				CoinJoinProcessor = new CoinJoinProcessor(Network, HostedServices.Get<WasabiSynchronizer>(), WalletManager, HttpClientFactory, BitcoinCoreNode?.RpcClient);
 
 				await StartRpcServerAsync(terminateService, cancel).ConfigureAwait(false);
 

--- a/WalletWasabi.Daemon/Global.cs
+++ b/WalletWasabi.Daemon/Global.cs
@@ -251,7 +251,7 @@ public class Global
 				Logger.LogInfo("Start synchronizing filters...");
 
 				TransactionBroadcaster.Initialize(HostedServices.Get<P2pNetwork>().Nodes, BitcoinCoreNode?.RpcClient);
-				CoinJoinProcessor = new CoinJoinProcessor(Network, HostedServices.Get<WasabiSynchronizer>(), WalletManager, HttpClientFactory, BitcoinCoreNode?.RpcClient);
+				CoinJoinProcessor = new CoinJoinProcessor(Network, HostedServices.Get<WasabiSynchronizer>(), WalletManager, HttpClientFactory.SharedWasabiClient, BitcoinCoreNode?.RpcClient);
 
 				await StartRpcServerAsync(terminateService, cancel).ConfigureAwait(false);
 

--- a/WalletWasabi/CoinJoin/Client/CoinJoinProcessor.cs
+++ b/WalletWasabi/CoinJoin/Client/CoinJoinProcessor.cs
@@ -19,12 +19,12 @@ public class CoinJoinProcessor : IDisposable
 {
 	private volatile bool _disposedValue = false; // To detect redundant calls
 
-	public CoinJoinProcessor(Network network, WasabiSynchronizer synchronizer, WalletManager walletManager, WasabiHttpClientFactory httpClientFactory, IRPCClient? rpc)
+	public CoinJoinProcessor(Network network, WasabiSynchronizer synchronizer, WalletManager walletManager, WasabiClient wasabiClient, IRPCClient? rpc)
 	{
 		Synchronizer = synchronizer;
 		WalletManager = walletManager;
 		Network = network;
-		HttpClientFactory = httpClientFactory;
+        WasabiClient = wasabiClient;
 		RpcClient = rpc;
 		ProcessLock = new AsyncLock();
 		Synchronizer.ResponseArrived += Synchronizer_ResponseArrivedAsync;
@@ -33,7 +33,7 @@ public class CoinJoinProcessor : IDisposable
 	private WasabiSynchronizer Synchronizer { get; }
 	private WalletManager WalletManager { get; }
 	private Network Network { get; }
-	private WasabiHttpClientFactory HttpClientFactory { get; }
+	private WasabiClient WasabiClient { get; }
 	private IRPCClient? RpcClient { get; set; }
 	private AsyncLock ProcessLock { get; }
 
@@ -51,8 +51,7 @@ public class CoinJoinProcessor : IDisposable
 
 				var txsNotKnownByAWallet = WalletManager.FilterUnknownCoinjoins(unconfirmedCoinJoinHashes);
 
-				var client = HttpClientFactory.SharedWasabiClient;
-				var unconfirmedCoinJoins = await client.GetTransactionsAsync(Network, txsNotKnownByAWallet, CancellationToken.None).ConfigureAwait(false);
+				var unconfirmedCoinJoins = await WasabiClient.GetTransactionsAsync(Network, txsNotKnownByAWallet, CancellationToken.None).ConfigureAwait(false);
 
 				foreach (var tx in unconfirmedCoinJoins.Select(x => new SmartTransaction(x, Height.Mempool)))
 				{

--- a/WalletWasabi/CoinJoin/Client/CoinJoinProcessor.cs
+++ b/WalletWasabi/CoinJoin/Client/CoinJoinProcessor.cs
@@ -30,11 +30,11 @@ public class CoinJoinProcessor : IDisposable
 		Synchronizer.ResponseArrived += Synchronizer_ResponseArrivedAsync;
 	}
 
-	public WasabiSynchronizer Synchronizer { get; }
-	public WalletManager WalletManager { get; }
-	public Network Network { get; }
+	private WasabiSynchronizer Synchronizer { get; }
+	private WalletManager WalletManager { get; }
+	private Network Network { get; }
 	private WasabiHttpClientFactory HttpClientFactory { get; }
-	public IRPCClient? RpcClient { get; private set; }
+	private IRPCClient? RpcClient { get; set; }
 	private AsyncLock ProcessLock { get; }
 
 	private async void Synchronizer_ResponseArrivedAsync(object? sender, SynchronizeResponse response)


### PR DESCRIPTION
This is just a PR that allows a bigger refactoring towards using .NET `HttpClient`'s `WebProxy` for Tor purposes. 

In any case, accessing "internals" of WasabiSynchronizer is not cool.