### PR TITLE
Fix path in RegTestFixture

### DIFF
--- a/WalletWasabi.Tests/XunitConfiguration/RegTestFixture.cs
+++ b/WalletWasabi.Tests/XunitConfiguration/RegTestFixture.cs
@@ -31,7 +31,7 @@ public class RegTestFixture : IDisposable
 		var walletName = "wallet";
 		BackendRegTestNode.RpcClient.CreateWalletAsync(walletName).GetAwaiter().GetResult();
 
-		var testnetBackendDir = EnvironmentHelpers.GetDataDir(Path.Combine(Common.DataDir, "RegTests", "Backend"));
+		var testnetBackendDir = Path.Combine(Common.DataDir, "RegTests", "Backend");
 		IoHelpers.TryDeleteDirectoryAsync(testnetBackendDir).GetAwaiter().GetResult();
 		Thread.Sleep(100);
 		Directory.CreateDirectory(testnetBackendDir);


### PR DESCRIPTION
`DataDir` already contains `EnvironmentHelpers.GetDataDir` so it was repeated twice.

Before:
![CleanShot 2024-05-22 at 19 16 25@2x](https://github.com/zkSNACKs/WalletWasabi/assets/16029533/0af4bfcf-3fb6-496c-8566-e4f8e27427a3)

After:
![CleanShot 2024-05-22 at 19 18 19@2x](https://github.com/zkSNACKs/WalletWasabi/assets/16029533/2819ebad-5a93-4369-8fde-c70a77709c4b)
