### PR TITLE
Remove test-only API Client `mempool-hashes`

### DIFF
--- a/WalletWasabi.Tests/IntegrationTests/LiveServerTests.cs
+++ b/WalletWasabi.Tests/IntegrationTests/LiveServerTests.cs
@@ -76,7 +76,7 @@ public class LiveServerTests : IAsyncLifetime
 		IEnumerable<Transaction> retrievedTxs = await client.GetTransactionsAsync(network, randomTxIds.Take(4), ctsTimeout.Token);
 		Assert.Empty(retrievedTxs);
 
-		var mempoolTxIds = await client.GetMempoolHashesAsync(ctsTimeout.Token);
+		var mempoolTxIds = (await client.GetMempoolHashesAsync(64, ctsTimeout.Token)).Select(uint256.Parse).ToArray();
 		randomTxIds = Enumerable.Range(0, 5).Select(_ => mempoolTxIds.RandomElement(InsecureRandom.Instance)!).Distinct().ToArray();
 		var txs = await client.GetTransactionsAsync(network, randomTxIds, ctsTimeout.Token);
 		var returnedTxIds = txs.Select(tx => tx.GetHash());

--- a/WalletWasabi/WebClients/Wasabi/WasabiClient.cs
+++ b/WalletWasabi/WebClients/Wasabi/WasabiClient.cs
@@ -158,25 +158,6 @@ public class WasabiClient
 		await BroadcastAsync(transaction.Transaction).ConfigureAwait(false);
 	}
 
-	public async Task<IEnumerable<uint256>> GetMempoolHashesAsync(CancellationToken cancel = default)
-	{
-		using HttpResponseMessage response = await HttpClient.SendAsync(
-			HttpMethod.Get,
-			$"api/v{ApiVersion}/btc/blockchain/mempool-hashes",
-			cancellationToken: cancel).ConfigureAwait(false);
-
-		if (response.StatusCode != HttpStatusCode.OK)
-		{
-			await response.ThrowRequestExceptionFromContentAsync(cancel).ConfigureAwait(false);
-		}
-
-		using HttpContent content = response.Content;
-		var strings = await content.ReadAsJsonAsync<IEnumerable<string>>().ConfigureAwait(false);
-		var ret = strings.Select(x => new uint256(x));
-
-		return ret;
-	}
-
 	/// <summary>
 	/// Gets mempool hashes, but strips the last x characters of each hash.
 	/// </summary>


### PR DESCRIPTION
`WasabiClient` had a `GetMempoolHashesAsync` method overloaded for testing purpose only. This is not okay and it is removed in this PR