### PR TITLE
Allow to run multiple backend instances

### DIFF
--- a/WalletWasabi.Backend/Controllers/WabiSabiController.cs
+++ b/WalletWasabi.Backend/Controllers/WabiSabiController.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using WalletWasabi.Backend.Filters;
 using WalletWasabi.Cache;
+using WalletWasabi.Helpers;
 using WalletWasabi.WabiSabi.Backend.PostRequests;
 using WalletWasabi.WabiSabi.Backend.Rounds;
 using WalletWasabi.WabiSabi.Backend.Statistics;
@@ -13,7 +14,7 @@ namespace WalletWasabi.Backend.Controllers;
 [ApiController]
 [ExceptionTranslate]
 [LateResponseLoggerFilter]
-[Route("[controller]")]
+[Route("api/v" + Constants.WabiSabiProtocolVersion + "/[controller]")]
 [Produces("application/json")]
 public class WabiSabiController : ControllerBase, IWabiSabiApiRequestHandler
 {

--- a/WalletWasabi.Backend/Controllers/WalletController.cs
+++ b/WalletWasabi.Backend/Controllers/WalletController.cs
@@ -23,7 +23,7 @@ namespace WalletWasabi.Backend.Controllers;
 /// To make batched requests.
 /// </summary>
 [Produces("application/json")]
-[Route("api/v" + Constants.BackendMajorVersion + "/[controller]")]
+[Route("api/v" + Constants.WalletProtocolVersion + "/[controller]")]
 public class WalletController : ControllerBase
 {
 	private static readonly MemoryCacheEntryOptions UnconfirmedTransactionChainCacheEntryOptions = new() { AbsoluteExpirationRelativeToNow = TimeSpan.FromSeconds(10) };

--- a/WalletWasabi.Backend/Program.cs
+++ b/WalletWasabi.Backend/Program.cs
@@ -23,5 +23,5 @@ public static class Program
 	public static IHostBuilder CreateHostBuilder(string[] args) =>
 		Host.CreateDefaultBuilder(args).ConfigureWebHostDefaults(webBuilder => webBuilder
 			.UseStartup<Startup>()
-			.UseUrls(Environment.GetEnvironmentVariable("WASABI_BIND") ?? "http://localhost:37127/"));
+			.UseUrls("http://localhost:37127/"));
 }

--- a/WalletWasabi.Backend/Properties/launchSettings.json
+++ b/WalletWasabi.Backend/Properties/launchSettings.json
@@ -5,8 +5,7 @@
       "launchBrowser": true,
       "launchUrl": "swagger",
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development",
-        "WASABI_BIND": "http://0.0.0.0:37127"
+        "ASPNETCORE_ENVIRONMENT": "Development"
       },
       "applicationUrl": "http://localhost:37127"
     }

--- a/WalletWasabi/Helpers/Constants.cs
+++ b/WalletWasabi/Helpers/Constants.cs
@@ -10,7 +10,9 @@ public static class Constants
 
 	public const string BackendUri = "https://api.wasabiwallet.io/";
 	public const string TestnetBackendUri = "https://api.wasabiwallet.co/";
-	public const string BackendMajorVersion = "4";
+	public const string BackendMajorVersion = "5";
+	public const string WalletProtocolVersion = "5";
+	public const string WabiSabiProtocolVersion = "2";
 
 	public const string WabiSabiFallBackCoordinatorExtPubKey = "xpub6C13JhXzjAhVRgeTcRSWqKEPe1vHi3Tmh2K9PN1cZaZFVjjSaj76y5NNyqYjc2bugj64LVDFYu8NZWtJsXNYKFb9J94nehLAPAKqKiXcebC";
 	public const string WasabiPubKey = "02c8ab8eea76c83788e246a1baee10c04a134ec11be6553946f6ae65e47ae9a608";

--- a/WalletWasabi/WabiSabi/Client/WabiSabiHttpApiClient.cs
+++ b/WalletWasabi/WabiSabi/Client/WabiSabiHttpApiClient.cs
@@ -9,6 +9,7 @@ using WalletWasabi.Tor.Http.Extensions;
 using WalletWasabi.WabiSabi.Backend.PostRequests;
 using WalletWasabi.WabiSabi.Models;
 using WalletWasabi.WabiSabi.Models.Serialization;
+using Constants = WalletWasabi.Helpers.Constants;
 
 namespace WalletWasabi.WabiSabi.Client;
 
@@ -157,7 +158,7 @@ public class WabiSabiHttpApiClient : IWabiSabiApiRequestHandler
 	}
 
 	private static string GetUriEndPoint(RemoteAction action) =>
-		"wabisabi/" + action switch
+		$"api/v{Constants.WabiSabiProtocolVersion}/wabisabi/" + action switch
 		{
 			RemoteAction.RegisterInput => "input-registration",
 			RemoteAction.RegisterOutput => "output-registration",

--- a/WalletWasabi/WebClients/Wasabi/WasabiClient.cs
+++ b/WalletWasabi/WebClients/Wasabi/WasabiClient.cs
@@ -28,7 +28,7 @@ public class WasabiClient
 	public static Dictionary<uint256, Transaction> TransactionCache { get; } = new();
 	private static Queue<uint256> TransactionIdQueue { get; } = new();
 	public static object TransactionCacheLock { get; } = new();
-	public static ushort ApiVersion { get; private set; } = ushort.Parse(Helpers.Constants.BackendMajorVersion);
+	public static ushort ApiVersion { get; private set; } = ushort.Parse(Helpers.Constants.WalletProtocolVersion);
 
 	/// <remarks>
 	/// Throws OperationCancelledException if <paramref name="cancel"/> is set.


### PR DESCRIPTION
This PR allows us to run multiple instances by doing something like: 
```
$ dotnet run --urls="http://localhost:38888/" --datadir="/home/userx/backend-datadir-1"
$ dotnet run --urls="http://localhost:39999/" --datadir="/home/userx/backend-datadir-2"
``````

`Wallet` API and `WabiSabi` API are now versioned, what allows us also to configure an http proxy easier.