### PR TITLE
[Trivial] Improve Tor connection error wording

### DIFF
--- a/WalletWasabi/Tor/TorProcessManager.cs
+++ b/WalletWasabi/Tor/TorProcessManager.cs
@@ -93,7 +93,13 @@ public class TorProcessManager : IAsyncDisposable
 			}
 		}
 
-		throw new InvalidOperationException($"No attempt to {operation} Tor was successful.");
+		if (_settings.TorMode == TorMode.Enabled)
+		{
+			throw new InvalidOperationException($"No attempt to start Tor was successful. Try to kill any running Tor instance using the activity monitor.");
+		}
+
+		throw new InvalidOperationException($"No attempt to connect to Tor was successful. It seems no Tor instance is currently running.\n" +
+		                                    $"Please start Tor before opening Wasabi or set 'UseTor' to 'Enabled' in the configuration file.");
 	}
 
 	/// <summary>Waits until Tor process is fully started or until it is stopped for some reason.</summary>


### PR DESCRIPTION
This is not a problem on Wasabi's side but on user side, as a result throwing is correct.
However, the error requires an action from the user, which is missing from the message.
This causes this problem (which again is not a problem) to be the number one request for support.
This PR should help some users without reaching for support because this message is shown in the crash reporter