### PR TITLE
Release Publisher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,8 +17,6 @@
 # Build results
 [Dd]ebug/
 [Dd]ebugPublic/
-[Rr]elease/
-[Rr]eleases/
 x64/
 x86/
 bld/

--- a/Contrib/Releases/Publisher/Program.fs
+++ b/Contrib/Releases/Publisher/Program.fs
@@ -1,0 +1,78 @@
+﻿open System
+open System.Net.WebSockets
+open System.Threading
+open Microsoft.FSharp.Collections
+open Microsoft.FSharp.Control
+open NBitcoin.Secp256k1
+open Nostra
+open Nostra.Client
+open System.IO
+
+let publishNote note (relay: Uri) =
+    let ws = new ClientWebSocket()
+    let ctx = Communication.buildContext ws Console.Out
+    let pushToRelay = Monad.injectedWith ctx (Communication.sender ())
+    async {
+        use cts = new CancellationTokenSource(TimeSpan.FromSeconds 10)
+        try
+            do! ws.ConnectAsync(relay, cts.Token) |> Async.AwaitTask
+            pushToRelay (Request.CMEvent note)
+            do! Async.Sleep (TimeSpan.FromSeconds 8)
+            return Ok relay
+        with ex ->
+            return Error (relay, ex.Message)
+    }
+
+let buildMessage content (tags : (string * string list) list) =
+    let links = tags |> List.map (fun (_, urls) -> List.head urls)
+    let linksSection = String.Join ("\n", links)
+    $"{content}\n\n# Links\n\n{linksSection}"
+
+let buildMessageTags version baseUri =
+    [
+        "SHA256SUMS"; "SHA256SUMS.asc"; "SHA256SUMS.wasabisig";
+        $"Wasabi-{version}-arm64.dmg"; $"Wasabi-{version}-arm64.dmg.asc";
+        $"Wasabi-{version}-linux-x64.tar.gz"; $"Wasabi-{version}-linux-x64.tar.gz.asc";
+        $"Wasabi-{version}-linux-x64.zip"; $"Wasabi-{version}-linux-x64.zip.asc";
+        $"Wasabi-{version}-macOS-arm64.zip"; $"Wasabi-{version}-macOS-arm64.zip.asc";
+        $"Wasabi-{version}-macOS-x64.zip"; $"Wasabi-{version}-macOS-x64.zip.asc";
+        $"Wasabi-{version}-win-x64.zip"; $"Wasabi-{version}-win-x64.zip.asc";
+        $"Wasabi-{version}.deb"; $"Wasabi-{version}.deb.asc";
+        $"Wasabi-{version}.dmg"; $"Wasabi-{version}.dmg.asc";
+        $"Wasabi-{version}.msi"; $"Wasabi-{version}.msi.asc"
+    ] |> List.map (fun file -> file, [$"{baseUri}/{file}"])
+
+
+[<EntryPoint>]
+let main args =
+    if args.Length < 3 then
+       printfn "Usage: program <version> <content-file-path> <private-key-hex>"
+       1
+    else
+        let version = args[0]
+        let content = File.ReadAllText args[1]
+        let secretHex = args[2] |> Utils.fromHex |> ECPrivKey.Create
+        let tags =  buildMessageTags version $"https://github.com/WalletWasabi/WalletWasabi/releases/download/v{version}"
+        let finalContent = buildMessage content tags
+        let unsignedNote = Event.createEvent Event.Kind.Text tags finalContent
+        let note = Event.sign secretHex unsignedNote
+
+        [
+            Uri "wss://relay.nostrified.org"
+            Uri "wss://relay.nostromo.social"
+            Uri "wss://nostr.l00p.org"
+            Uri "wss://relay.damus.io"
+            Uri "wss://relay.primal.net"
+            Uri "wss://nostr.mom"
+            Uri "wss://nos.lol"
+            Uri "wss://purplerelay.com"
+            Uri "wss://eden.nostr.land"
+        ]
+        |> List.map (publishNote note)
+        |> Async.Parallel
+        |> Async.RunSynchronously
+        |> Array.map (function
+                     | Ok relay -> $"✅ Successfully published to {relay}"
+                     | Error (relay, msg) -> $"❌ Failed to publish to {relay} {msg}")
+        |> Array.iter Console.WriteLine
+        0

--- a/Contrib/Releases/Publisher/Publisher.fsproj
+++ b/Contrib/Releases/Publisher/Publisher.fsproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ManagePackageVersionsCentrally>false</ManagePackageVersionsCentrally>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Nostra" Version="0.0.1" />
+  </ItemGroup>
+
+</Project>

--- a/Contrib/Releases/Publisher/README.md
+++ b/Contrib/Releases/Publisher/README.md
@@ -1,0 +1,14 @@
+# Publish
+
+A command line tool to announce releases on nostr.
+
+# How to play with it
+
+```bash
+$ dotnet run <release-version> <announcement-content-file-path> <secret-key-hex>
+```
+
+Example:
+```bash
+dotnet run "2.46.5" "../../../WalletWasabi/Announcements/ReleaseHighlights.md" "b76950102f2cf9df470474a344621d6f25d10946aef0451f7ff3cb30152ebedd"
+```


### PR DESCRIPTION
Published a release announcement with links to github releases.
If tomorrow we need to publish our releases on IPFS, Torrent or any other site we would need to update this script.


https://primal.net/e/nevent1qqsvl6ul6t32k6282mgg8qnlghxwr8e2wv0u2rhgg8nxec82qztl3rgv5g7x5