### PR TITLE
Ensure Mainnet after migrating from v2.6.0

### DIFF
--- a/WalletWasabi.Daemon/WasabiApplication.cs
+++ b/WalletWasabi.Daemon/WasabiApplication.cs
@@ -183,8 +183,6 @@ public class WasabiApplication
 				MaxCoinJoinMiningFeeRate : oldConfig.MaxCoinJoinMiningFeeRate,
 				MaxDaysInMempool: oldConfig.MaxDaysInMempool
 			);
-			var mainnetConfigFilePath = Path.Combine(Config.DataDir, "Config.json");
-			PersistentConfigManager.ToFile(mainnetConfigFilePath, mainConfig);
 
 			var testConfig = mainConfig with
 			{
@@ -194,8 +192,6 @@ public class WasabiApplication
 				BitcoinRpcCredentialString = oldConfig.TestNetBitcoinRpcCredentialString,
 				BitcoinRpcUri = oldConfig.TestNetBitcoinRpcEndPoint.ToUriString("http"),
 			};
-			var testnetConfigFilePath = Path.Combine(Config.DataDir, "Config.TestNet.json");
-			PersistentConfigManager.ToFile(testnetConfigFilePath, testConfig);
 
 			var regtestConfig = mainConfig with
 			{
@@ -205,8 +201,15 @@ public class WasabiApplication
 				BitcoinRpcCredentialString = oldConfig.RegTestBitcoinRpcCredentialString,
 				BitcoinRpcUri = oldConfig.RegTestBitcoinRpcEndPoint.ToUriString("http"),
 			};
+
 			var regtestConfigFilePath = Path.Combine(Config.DataDir, "Config.RegTest.json");
 			PersistentConfigManager.ToFile(regtestConfigFilePath, regtestConfig);
+
+			var testnetConfigFilePath = Path.Combine(Config.DataDir, "Config.TestNet.json");
+			PersistentConfigManager.ToFile(testnetConfigFilePath, testConfig);
+
+			var mainnetConfigFilePath = Path.Combine(Config.DataDir, "Config.json");
+			PersistentConfigManager.ToFile(mainnetConfigFilePath, mainConfig);
 		}
 	}
 


### PR DESCRIPTION
Fixes: #14028 

`PersistentConfigManager.ToFile()` writes the corresponding network to the `network` file.

In the `MigrateConfigFiles()` method we saved (called  `PersistentConfigManager.ToFile()`) the RegTest config last, so the network was always set to RegTest after migration.

This PR makes sure Mainnet is saved last, therefore WW will launch in Mainnet after migration.