### PR TITLE
Makes sameTxAllowance to average 2 as per specs in comment.

### DIFF
--- a/WalletWasabi/WabiSabi/Client/CoinJoin/Client/CoinJoinCoinSelector.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoin/Client/CoinJoinCoinSelector.cs
@@ -211,7 +211,7 @@ public class CoinJoinCoinSelector
 		Logger.LogDebug($"Selected the final selection candidate: {finalCandidate.Count()} coins, {string.Join(", ", finalCandidate.Select(x => x.Amount.ToString(false, true)).ToArray())} BTC.");
 
 		// Let's remove some coins coming from the same tx in the final candidate, allow 2 on average.
-		int sameTxAllowance = _generator.GetRandomBiasedSameTxAllowance(33);
+		int sameTxAllowance = _generator.GetRandomBiasedSameTxAllowance(80);
 
 		List<TCoin> winner = new()
 		{


### PR DESCRIPTION
`// Let's remove some coins coming from the same tx in the final candidate, allow 2 on average.`

Average = 0.5 

Before:

* 0.67^1 = 0.67
* 0.67^2 = 0.4489
* **0.67^3 = 0.300763**
* 0.67^4 = 0.20151121
* 0.67^5 = 0.1340125

After: 

| y | 0.8^y     |
|---|-----------|
| 1 | 0.8       |
| 2 | 0.64      |
| 3 | **0.512**     |
| 4 | 0.4096    |
| 5 | 0.32768   |

starting at 0, 3rd loop = 2

https://github.com/WalletWasabi/WalletWasabi/issues/13552