### PR TITLE
Display receive button always

### DIFF
--- a/WalletWasabi.Fluent/Views/Wallets/WalletView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/WalletView.axaml
@@ -64,6 +64,15 @@
               </SubActionButton.SubCommands>
             </SubActionButton>
 
+            <Button
+              Classes="function"
+              Command="{Binding SegwitReceiveCommand}"
+              IsVisible="{Binding SeveralReceivingScriptTypes, Converter={x:Static BoolConverters.Not}}">
+              <StackPanel Orientation="Horizontal">
+               <PathIcon Data="{StaticResource wallet_action_receive}" />
+                <TextBlock Text="Receive" />
+              </StackPanel>
+            </Button>
             <SubActionButton Content="Receive"
                              Command="{Binding DefaultReceiveCommand}"
                              VerticalAlignment="Bottom"


### PR DESCRIPTION
The receive button was visible only when `SeveralReceivingScriptTypes` were available (segwit and taproot). However for hww the taproot type is not available, this means that for hww users the receive button was not available.

Fixes: https://github.com/WalletWasabi/WalletWasabi/issues/14088