### PR TITLE
doc: update min OS versions and remove full node as dependency

### DIFF
--- a/WalletWasabi.Documentation/WasabiCompatibility.md
+++ b/WalletWasabi.Documentation/WasabiCompatibility.md
@@ -6,10 +6,10 @@ This document lists all the officially supported software and devices by Wasabi 
 
 - Windows 10 1607+
 - Windows 11 22000+
-- macOS 12.0+
+- macOS 13.0+
 - Ubuntu 22.04+
-- Fedora 37+
-- Debian 11+
+- Fedora 41+
+- Debian 12+
 
 # Officially Supported Hardware Wallets
 


### PR DESCRIPTION
Remove Knots/Core as listed dependency.

Then I saw that the supported OS's should be bumped too, according to https://github.com/dotnet/core/blob/main/release-notes/8.0/supported-os.md.