### PR TITLE
Fix error sending when no estimations are available

### DIFF
--- a/WalletWasabi.Fluent/Helpers/TransactionFeeHelper.cs
+++ b/WalletWasabi.Fluent/Helpers/TransactionFeeHelper.cs
@@ -76,12 +76,21 @@ public static class TransactionFeeHelper
 	public static bool TryGetFeeEstimates(Wallet wallet, [NotNullWhen(true)] out FeeRateEstimations? estimates)
 		=> TryGetFeeEstimates(wallet.FeeRateEstimations, wallet.Network, out estimates);
 
-	public static bool TryGetFeeEstimates(FeeRateEstimations feeRateEstimations, Network network, [NotNullWhen(true)] out FeeRateEstimations? estimates)
+	public static bool TryGetFeeEstimates(FeeRateEstimations? feeRateEstimations, Network network, [NotNullWhen(true)] out FeeRateEstimations? estimates)
 	{
-		estimates = null;
+		if (network == Network.TestNet)
+		{
+			estimates = TestNetFeeRateEstimations;
+			return true;
+		}
+		if (feeRateEstimations is not null)
+		{
+			estimates = feeRateEstimations;
+			return true;
+		}
 
-		estimates = network == Network.TestNet ? TestNetFeeRateEstimations : feeRateEstimations;
-		return true;
+		estimates = null;
+		return false;
 	}
 
 	public static TimeSpan CalculateConfirmationTime(double targetBlock)

--- a/WalletWasabi.Fluent/Models/Wallets/TransactionTreeBuilder.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/TransactionTreeBuilder.cs
@@ -120,6 +120,7 @@ public class TransactionTreeBuilder
 		var date = transactionSummary.FirstSeen.ToLocalTime();
 		var confirmations = transactionSummary.GetConfirmations();
 		var status = GetItemStatus(transactionSummary);
+		var haveFeeEstimations = _wallet.FeeRateEstimations is not null;
 
 		return new TransactionModel
 		{
@@ -131,8 +132,8 @@ public class TransactionTreeBuilder
 			Date = date,
 			DateString = date.ToUserFacingFriendlyString(),
 			DateToolTipString = date.ToUserFacingString(),
-			CanCancelTransaction = transactionSummary.Transaction.IsCancellable(_wallet.KeyManager),
-			CanSpeedUpTransaction = transactionSummary.Transaction.IsSpeedupable(_wallet.KeyManager),
+			CanCancelTransaction = transactionSummary.Transaction.IsCancellable(_wallet.KeyManager) && haveFeeEstimations,
+			CanSpeedUpTransaction = transactionSummary.Transaction.IsSpeedupable(_wallet.KeyManager) && haveFeeEstimations,
 			Type = itemType,
 			Status = status,
 			Confirmations = confirmations,

--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -83,7 +83,7 @@ public class Wallet : BackgroundService, IWallet
 	public BitcoinStore BitcoinStore { get; }
 	public KeyManager KeyManager { get; }
 	public ServiceConfiguration ServiceConfiguration { get; }
-	public FeeRateEstimations FeeRateEstimations { get; private set; }
+	public FeeRateEstimations? FeeRateEstimations { get; private set; }
 	public string WalletName => KeyManager.WalletName;
 
 	public CoinsRegistry Coins { get; }


### PR DESCRIPTION
Fix https://github.com/WalletWasabi/WalletWasabi/issues/14125.

There was also a problem when trying to speed up a transaction if the fee rate provider is None.