### PR TITLE
Disable Silent Payments for Hardware wallets

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/SendViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/SendViewModel.cs
@@ -291,6 +291,11 @@ public partial class SendViewModel : RoutableViewModel
 				errors.Add(ErrorSeverity.Error, parseResult.Error);
 				return;
 			}
+			if (parseResult is {IsOk: true, Value: Address.SilentPayment} && _walletModel.IsHardwareWallet)
+			{
+				errors.Add(ErrorSeverity.Error, "Silent payments are not possible with hardware wallets.");
+				return;
+			}
 		}
 
 		if (IsPayJoin && _walletModel.IsHardwareWallet)

--- a/WalletWasabi.Tests/UnitTests/Transactions/TransactionFactoryTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Transactions/TransactionFactoryTests.cs
@@ -609,6 +609,22 @@ public class TransactionFactoryTests
 		Assert.False(result.Signed);
 	}
 
+	[Fact]
+	public void DoNotSilentPaymentWithWatchOnly()
+	{
+		var transactionFactory = ServiceFactory.CreateTransactionFactory(
+			new[]
+			{
+				("Pablo", 0, 1m, confirmed: true, anonymitySet: 1)
+			},
+			watchOnly: true);
+
+		var key = SilentPaymentAddress.Parse("sp1qq2exrz9xjumnvujw7zmav4r3vhfj9rvmd0aytjx0xesvzlmn48ctgqnqdgaan0ahmcfw3cpq5nxvnczzfhhvl3hmsps683cap4y696qecs7wejl3", Network.Main);
+		var payment = new PaymentIntent(key, MoneyRequest.CreateAllRemaining(subtractFee: true));
+		var txParameters = CreateBuilder().SetPayment(payment).SetFeeRate(44.25m).Build();
+		Assert.Throws<InvalidOperationException>(() => transactionFactory.BuildTransaction(txParameters));
+	}
+
 	/// <summary>
 	/// Tests that we throw <see cref="TransactionSizeException"/> when NBitcoin returns a coin selection whose sum is lower than the desired one.
 	/// This can happen because bitcoin transactions can have only a limited number of coin inputs because of the transaction size limit.

--- a/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
+++ b/WalletWasabi/Blockchain/Transactions/TransactionFactory.cs
@@ -49,6 +49,13 @@ public class TransactionFactory
 			throw new ArgumentOutOfRangeException($"{nameof(payments)}.{nameof(payments.TotalAmount)} sum cannot be smaller than 0 or greater than {Constants.MaximumNumberOfSatoshis}.");
 		}
 
+		var isSilentPayment = payments.Requests.Select(x => x.Destination).OfType<Destination.Silent>().Any();
+		var canUsePrivateKeys = !KeyManager.IsWatchOnly && parameters.TryToSign;
+		if (isSilentPayment && !canUsePrivateKeys)
+		{
+			throw new InvalidOperationException("Silent payments requires a hot wallet.");
+		}
+
 		// Get allowed coins to spend.
 		var availableCoinsView = Coins.Unspent();
 		if (parameters.AllowDoubleSpend && parameters.AllowedInputs is not null)


### PR DESCRIPTION
Silent payments require key material then hardware wallets cannot be used.