### PR TITLE
add block.xyz fee provider

### DIFF
--- a/WalletWasabi.Daemon/Config/Config.cs
+++ b/WalletWasabi.Daemon/Config/Config.cs
@@ -116,7 +116,7 @@ public class Config
 				"The BTC/USD exchange rate provider. Available providers are MempoolSpace (default), Gemini, BlockstreamInfo, CoinGecko or None",
 				GetStringValue("ExchangeRateProvider", PersistentConfig.ExchangeRateProvider, cliArgs)),
 			[ nameof(FeeRateEstimationProvider) ] = (
-				"The mining fee rate estimation provider. Available providers are (default) MempoolSpace, BlockstreamInfo, Block.xyz or None",
+				"The mining fee rate estimation provider. Available providers are (default) MempoolSpace, BlockstreamInfo, BlockXyz or None",
 				GetStringValue("FeeRateEstimationProvider", PersistentConfig.FeeRateEstimationProvider, cliArgs)),
 			[ nameof(ExternalTransactionBroadcaster) ] = (
 				"Third party transaction broadcaster. Available broadcasters are (default) MempoolSpace and BlockstreamInfo",

--- a/WalletWasabi.Daemon/Global.cs
+++ b/WalletWasabi.Daemon/Global.cs
@@ -221,7 +221,7 @@ public class Global
 		var blockstreamInfoFeeProvider = FeeRateProviders.BlockstreamAsync(ExternalSourcesHttpClientFactory);
 		FeeRateProvider feeRateProvider = Config.FeeRateEstimationProvider.ToLower() switch
 		{
-			"block.xyz" => FeeRateProviders.Composed([blockFeeProvider, mempoolSpaceFeeProvider, blockstreamInfoFeeProvider]),
+			"blockxyz" => FeeRateProviders.Composed([blockFeeProvider, mempoolSpaceFeeProvider, blockstreamInfoFeeProvider]),
 			"mempoolspace" => FeeRateProviders.Composed([mempoolSpaceFeeProvider, blockstreamInfoFeeProvider]),
 			"blockstreaminfo" => FeeRateProviders.Composed([blockstreamInfoFeeProvider, mempoolSpaceFeeProvider]),
 			"" or "none" => FeeRateProviders.NoneAsync(),

--- a/WalletWasabi/FeeRateEstimation/FeeRateProviders.cs
+++ b/WalletWasabi/FeeRateEstimation/FeeRateProviders.cs
@@ -24,7 +24,7 @@ public static class FeeRateProviders
 	public static readonly ImmutableArray<string> Providers =
 	[
 		"BlockstreamInfo",
-		"Block.xyz",
+		"BlockXyz",
 		"MempoolSpace",
 		"None"
 	];


### PR DESCRIPTION
block.xyz recently open-sourced a new fee estimator and published long blog post how it performs very better than mempool.space and blockstream and others. It saves users money and makes sure transactions get confirmed with good fees.
this PR adds the fee provider to Wasabi Wallet

fees are published here: https://pricing.bitcoin.block.xyz/fees
blog post with many more details: https://engineering.block.xyz/blog/augur-an-open-source-bitcoin-fee-estimation-library

