### PR TITLE
Fix exception when copy and pasting a bitcoin address with leading/trailing whitespace

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/Wallets/Send/SendViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Send/SendViewModel.cs
@@ -283,27 +283,16 @@ public partial class SendViewModel : RoutableViewModel
 
 	private void ValidateToField(IValidationErrors errors)
 	{
-		if (!string.IsNullOrEmpty(To))
+		var parseResult = AddressParser.Parse(To, _walletModel.Network);
+		if (!parseResult.IsOk)
 		{
-			var parseResult = AddressParser.Parse(To, _walletModel.Network);
-			if (!string.IsNullOrEmpty(To) && (To.IsTrimmable() || !parseResult.IsOk))
-			{
-				if (parseResult.IsOk)
-				{
-					errors.Add(ErrorSeverity.Error, "Leading or trailing whitespace detected. Remove it please.");
-				}
-				else
-				{
-					errors.Add(ErrorSeverity.Error, parseResult.Error);
-				}
-
-				return;
-			}
-			if (parseResult is {IsOk: true, Value: Address.SilentPayment} && _walletModel.IsHardwareWallet)
-			{
-				errors.Add(ErrorSeverity.Error, "Silent payments are not possible with hardware wallets.");
-				return;
-			}
+			errors.Add(ErrorSeverity.Error, parseResult.Error);
+			return;
+		}
+		if (parseResult is {Value: Address.SilentPayment} && _walletModel.IsHardwareWallet)
+		{
+			errors.Add(ErrorSeverity.Error, "Silent payments are not possible with hardware wallets.");
+			return;
 		}
 
 		if (IsPayJoin && _walletModel.IsHardwareWallet)

--- a/WalletWasabi.Fluent/Views/Wallets/Send/SendView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Send/SendView.axaml
@@ -97,6 +97,7 @@
       <!-- To -->
       <DockPanel DockPanel.Dock="Top" Margin="0,0,0,10" MaxHeight="63">
         <Label DockPanel.Dock="Left" Content="_To:" Target="toTb" />
+
         <TextBox x:Name="toTb" MaxLength="250" Text="{Binding To}" Classes="monoSpaced"
                  IsReadOnly="{Binding IsFixedAddress}"
                  Watermark="(e.g. Bitcoin address, Silent Payment address or payjoin URL)"
@@ -107,6 +108,8 @@
             <FocusOnAttachedBehavior />
             <ExecuteCommandOnActivatedBehavior Command="{Binding AutoPasteCommand}" />
             <FocusNextWhenValidBehavior />
+            <WhitespacePasteRemovalBehavior />
+            <WhitespaceInputRemovalBehavior />
             <KeyDownTrigger Key="Enter" EventRoutingStrategy="Tunnel" MarkAsHandled="False">
               <InvokeCommandAction Command="{Binding #amountTb.FocusCommand}"/>
             </KeyDownTrigger>


### PR DESCRIPTION
Scenario:

1. Click "Send" button
2. Copy and paste `1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa ` (with the trailing space)
3. You should see and exception

