### PR TITLE
Fix error after receiving transactions

### DIFF
--- a/WalletWasabi.Fluent/Models/Wallets/WalletTransactionsModel.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/WalletTransactionsModel.cs
@@ -46,13 +46,13 @@ public partial class WalletTransactionsModel : ReactiveObject, IDisposable
 
 		NewTransactionArrived =
 			Observable.FromEventPattern<ProcessedResult>(wallet, nameof(wallet.WalletRelevantTransactionProcessed))
-					  .Select(x => (walletModel, x.EventArgs))
-					  .ObserveOn(RxApp.MainThreadScheduler);
-
-		RequestedCpfpInfoArrived = Services.EventBus.AsObservable<CpfpInfoArrived>().ToSignal()
+				.Select(x => (walletModel, x.EventArgs))
 				.ObserveOn(RxApp.MainThreadScheduler);
 
-		Cache = (RequestedCpfpInfoArrived is null ? TransactionProcessed : TransactionProcessed.Merge(RequestedCpfpInfoArrived))
+		RequestedCpfpInfoArrived = Services.EventBus.AsObservable<CpfpInfoArrived>().ToSignal()
+			.ObserveOn(RxApp.MainThreadScheduler);
+
+		Cache = TransactionProcessed.Merge(RequestedCpfpInfoArrived)
 			.FetchAsync(() => BuildSummaryAsync(CancellationToken.None), model => model.Id)
 			.DisposeWith(_disposable);
 
@@ -66,7 +66,7 @@ public partial class WalletTransactionsModel : ReactiveObject, IDisposable
 	public IObservable<Unit> TransactionProcessed { get; }
 
 	public IObservable<(IWalletModel Wallet, ProcessedResult EventArgs)> NewTransactionArrived { get; }
-	public IObservable<Unit>? RequestedCpfpInfoArrived { get; }
+	public IObservable<Unit> RequestedCpfpInfoArrived { get; }
 
 	public bool TryGetById(uint256 transactionId, bool isChild, [NotNullWhen(true)] out TransactionModel? transaction)
 	{

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Home/History/HistoryViewModel.cs
@@ -139,7 +139,8 @@ public partial class HistoryViewModel : ActivatableViewModel
 
 	public void SelectTransaction(uint256 txid)
 	{
-		var txnItem = Transactions.FirstOrDefault(item =>
+		var transactionsSnapshot = Transactions.ToArray();
+		var txnItem = transactionsSnapshot.FirstOrDefault(item =>
 		{
 			if (item is CoinJoinsHistoryItemViewModel cjGroup)
 			{
@@ -156,7 +157,7 @@ public partial class HistoryViewModel : ActivatableViewModel
 
 			// TDG has a visual glitch, if the item is not visible in the list, it will be glitched when gets expanded.
 			// Selecting first the root item, then the child solves the issue.
-			var index = Transactions.IndexOf(txnItem);
+			var index = transactionsSnapshot.IndexOf(txnItem);
 			Dispatcher.UIThread.Post(() => selection.SelectedIndex = new IndexPath(index));
 
 			if (txnItem is CoinJoinsHistoryItemViewModel cjGroup &&


### PR DESCRIPTION
Close: https://github.com/WalletWasabi/WalletWasabi/issues/14151

No matter how much I tried to reproduce it, it never happened to me. For this reason I applied the "standard solution" for that kind of problems but I cannot verify the problem was really fixed.

It is important however to verify it doesn't break anything. The error occurred when a new transaction was added to the history view, that's why it happened to people coinjoining and other immediately after sending.