### PR TITLE
Fetch filters from rpc only when it is running and synchronized

### DIFF
--- a/WalletWasabi.Daemon/Global.cs
+++ b/WalletWasabi.Daemon/Global.cs
@@ -260,12 +260,23 @@ public class Global
 		ICompactFilterProvider filtersProvider = await GetFilterProviderAsync() ??
 		                                         throw new NotSupportedException("Neither backend URI is specified nor a Bitcoin RPC client able to provide compact filters exists.");
 
-		Spawn("Synchronizer",
-			Service("Wasabi Index-Based Synchronizer",
-				Continuously(
-					Synchronizer.CreateFilterGenerator(filtersProvider, BitcoinStore, EventBus)
-				)), cancellationToken)
+		var (pause, resume, serviceLoop) =
+			Continuously(Synchronizer.CreateFilterGenerator(filtersProvider, BitcoinStore, EventBus));
+
+		Spawn("Synchronizer", Service("Wasabi Index-Based Synchronizer", serviceLoop), cancellationToken)
 			.DisposeUsing(_disposables);
+
+		if (filtersProvider is BitcoinRpcFilterProvider)
+		{
+			EventBus.Subscribe<RpcStatusChanged>(e =>
+			{
+				var action = e.Status.Match(
+					x => x.Synchronized ? resume : pause,
+					_ => pause);
+				action();
+			});
+		}
+
 		return;
 
 		async Task<ICompactFilterProvider?> GetFilterProviderAsync()

--- a/WalletWasabi.Tests/IntegrationTests/P2pTests.cs
+++ b/WalletWasabi.Tests/IntegrationTests/P2pTests.cs
@@ -87,7 +87,8 @@ public class P2pTests
 		KeyManager keyManager = KeyManager.CreateNew(out _, "password", network!);
 		var httpClientFactory = new CoordinatorHttpClientFactory(new Uri("http://localhost:12345"), new HttpClientFactory());
 		var filterProvider = new WebApiFilterProvider(10_000, httpClientFactory, eventBus);
-		using var synchronizer = Spawn("Synchronizer", Continuously(Synchronizer.CreateFilterGenerator(filterProvider, bitcoinStore, eventBus)));
+		var (_, _, serviceLoop) = Continuously(Synchronizer.CreateFilterGenerator(filterProvider, bitcoinStore, eventBus));
+		using var synchronizer = Spawn("Synchronizer", serviceLoop);
 
 		using MemoryCache cache = new(new MemoryCacheOptions
 		{

--- a/WalletWasabi.Tests/RegressionTests/BuildTransactionReorgsTest.cs
+++ b/WalletWasabi.Tests/RegressionTests/BuildTransactionReorgsTest.cs
@@ -58,7 +58,8 @@ public class BuildTransactionReorgsTest : IClassFixture<RegTestFixture>
 		// 3. Create wasabi synchronizer service.
 		var httpClientFactory = RegTestFixture.IndexerHttpClientFactory;
 		var filterProvider = new WebApiFilterProvider(10_000, httpClientFactory, setup.EventBus);
-		using var synchronizer = Spawn("Synchronizer", Continuously(Synchronizer.CreateFilterGenerator(filterProvider, bitcoinStore, setup.EventBus)));
+		var (_, _, serviceLoop) = Continuously(Synchronizer.CreateFilterGenerator(filterProvider, bitcoinStore, setup.EventBus));
+		using var synchronizer = Spawn("Synchronizer", serviceLoop);
 
 		// 4. Create key manager service.
 		var keyManager = KeyManager.CreateNew(out _, password, network);

--- a/WalletWasabi.Tests/RegressionTests/BuildTransactionValidationsTest.cs
+++ b/WalletWasabi.Tests/RegressionTests/BuildTransactionValidationsTest.cs
@@ -57,7 +57,8 @@ public class BuildTransactionValidationsTest : IClassFixture<RegTestFixture>
 
 		// 3. Create wasabi synchronizer service.
 		var filterProvider = new WebApiFilterProvider(10_000, RegTestFixture.IndexerHttpClientFactory,  setup.EventBus);
-		using var synchronizer = Spawn("Synchronizer", Continuously(Synchronizer.CreateFilterGenerator(filterProvider, bitcoinStore, setup.EventBus)));
+		var (_, _, serviceLoop) = Continuously(Synchronizer.CreateFilterGenerator(filterProvider, bitcoinStore, setup.EventBus));
+		using var synchronizer = Spawn("Synchronizer", serviceLoop);
 
 		// 4. Create key manager service.
 		var keyManager = KeyManager.CreateNew(out _, password, network);

--- a/WalletWasabi.Tests/RegressionTests/CancelTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/CancelTests.cs
@@ -58,7 +58,8 @@ public class CancelTests : IClassFixture<RegTestFixture>
 		// 3. Create wasabi synchronizer service.
 		var httpClientFactory = RegTestFixture.IndexerHttpClientFactory;
 		var filterProvider = new WebApiFilterProvider(10_000, httpClientFactory, setup.EventBus);
-		using var synchronizer = Spawn("Synchronizer", Continuously(Synchronizer.CreateFilterGenerator(filterProvider, bitcoinStore, setup.EventBus)));
+		var (_, _, serviceLoop) = Continuously(Synchronizer.CreateFilterGenerator(filterProvider, bitcoinStore, setup.EventBus));
+		using var synchronizer = Spawn("Synchronizer", serviceLoop);
 
 		// 4. Create key manager service.
 		var keyManager = KeyManager.CreateNew(out _, password, network);

--- a/WalletWasabi.Tests/RegressionTests/FilterDownloaderTest.cs
+++ b/WalletWasabi.Tests/RegressionTests/FilterDownloaderTest.cs
@@ -33,7 +33,8 @@ public class FilterDownloaderTest : IClassFixture<RegTestFixture>
 		BitcoinStore bitcoinStore = setup.BitcoinStore;
 
 		var filterProvider = new WebApiFilterProvider(10_000, RegTestFixture.IndexerHttpClientFactory, setup.EventBus);
-		using var synchronizer = Spawn("Synchronizer", Continuously(Synchronizer.CreateFilterGenerator(filterProvider, bitcoinStore, setup.EventBus)));
+		var (_, _, serviceLoop) = Continuously(Synchronizer.CreateFilterGenerator(filterProvider, bitcoinStore, setup.EventBus));
+		using var synchronizer = Spawn("Synchronizer", serviceLoop);
 		var blockCount = await rpc.GetBlockCountAsync() + 1; // Plus one because of the zeroth.
 		// Test initial synchronization.
 		var times = 0;

--- a/WalletWasabi.Tests/RegressionTests/MaxFeeTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/MaxFeeTests.cs
@@ -60,7 +60,8 @@ public class MaxFeeTests : IClassFixture<RegTestFixture>
 		// 3. Create wasabi synchronizer service.
 		var httpClientFactory = RegTestFixture.IndexerHttpClientFactory;
 		var filterProvider = new WebApiFilterProvider(10_000, httpClientFactory, setup.EventBus);
-		using var synchronizer = Spawn("Synchronizer", Continuously(Synchronizer.CreateFilterGenerator(filterProvider, bitcoinStore, setup.EventBus)));
+		var (_, _, serviceLoop) = Continuously(Synchronizer.CreateFilterGenerator(filterProvider, bitcoinStore, setup.EventBus));
+		using var synchronizer = Spawn("Synchronizer", serviceLoop);
 
 		// 4. Create key manager service.
 		var keyManager = KeyManager.CreateNew(out _, password, network);

--- a/WalletWasabi.Tests/RegressionTests/ReceiveSpeedupTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/ReceiveSpeedupTests.cs
@@ -60,7 +60,8 @@ public class ReceiveSpeedupTests : IClassFixture<RegTestFixture>
 		// 3. Create wasabi synchronizer service.
 		var httpClientFactory = RegTestFixture.IndexerHttpClientFactory;
 		var filterProvider = new WebApiFilterProvider(10_000, httpClientFactory, setup.EventBus);
-		using var synchronizer = Spawn("Synchronizer", Continuously(Synchronizer.CreateFilterGenerator(filterProvider, bitcoinStore, setup.EventBus)));
+		var (_, _, serviceLoop) = Continuously(Synchronizer.CreateFilterGenerator(filterProvider, bitcoinStore, setup.EventBus));
+		using var synchronizer = Spawn("Synchronizer", serviceLoop);
 
 		// 4. Create key manager service.
 		var keyManager = KeyManager.CreateNew(out _, password, network);

--- a/WalletWasabi.Tests/RegressionTests/ReorgTest.cs
+++ b/WalletWasabi.Tests/RegressionTests/ReorgTest.cs
@@ -72,7 +72,8 @@ public class ReorgTest : IClassFixture<RegTestFixture>
 		await rpc.GenerateAsync(2); // Generate two, so we can test for two reorg
 
 		var filterProvider = new WebApiFilterProvider(10_000, RegTestFixture.IndexerHttpClientFactory, setup.EventBus);
-		using var synchronizer = Spawn("Synchronizer", Continuously(Synchronizer.CreateFilterGenerator(filterProvider, bitcoinStore, setup.EventBus)));
+		var (_, _, serviceLoop) = Continuously(Synchronizer.CreateFilterGenerator(filterProvider, bitcoinStore, setup.EventBus));
+		using var synchronizer = Spawn("Synchronizer", serviceLoop);
 
 		var reorgAwaiter = new EventsAwaiter<FilterModel>(
 			h => bitcoinStore.FilterStore.Reorged += h,

--- a/WalletWasabi.Tests/RegressionTests/ReplaceByFeeTxTest.cs
+++ b/WalletWasabi.Tests/RegressionTests/ReplaceByFeeTxTest.cs
@@ -53,7 +53,8 @@ public class ReplaceByFeeTxTest : IClassFixture<RegTestFixture>
 
 		// 3. Create wasabi synchronizer service.
 		var filterProvider = new WebApiFilterProvider(10_000, RegTestFixture.IndexerHttpClientFactory, setup.EventBus);
-		using var synchronizer = Spawn("Synchronizer", Continuously(Synchronizer.CreateFilterGenerator(filterProvider, bitcoinStore, setup.EventBus)));
+		var (_, _, serviceLoop) = Continuously(Synchronizer.CreateFilterGenerator(filterProvider, bitcoinStore, setup.EventBus));
+		using var synchronizer = Spawn("Synchronizer", serviceLoop);
 
 		// 4. Create key manager service.
 		var keyManager = KeyManager.CreateNew(out _, password, network);

--- a/WalletWasabi.Tests/RegressionTests/SelfSpendSpeedupTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/SelfSpendSpeedupTests.cs
@@ -61,7 +61,8 @@ public class SelfSpendSpeedupTests : IClassFixture<RegTestFixture>
 		// 3. Create wasabi synchronizer service.
 		var httpClientFactory = RegTestFixture.IndexerHttpClientFactory;
 		var filterProvider = new WebApiFilterProvider(10_000, httpClientFactory, setup.EventBus);
-		using var synchronizer = Spawn("Synchronizer", Continuously(Synchronizer.CreateFilterGenerator(filterProvider, bitcoinStore, setup.EventBus)));
+		var (_, _, serviceLoop) = Continuously(Synchronizer.CreateFilterGenerator(filterProvider, bitcoinStore, setup.EventBus));
+		using var synchronizer = Spawn("Synchronizer", serviceLoop);
 
 		// 4. Create key manager service.
 		var keyManager = KeyManager.CreateNew(out _, password, network);

--- a/WalletWasabi.Tests/RegressionTests/SendSpeedupTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/SendSpeedupTests.cs
@@ -60,7 +60,8 @@ public class SendSpeedupTests : IClassFixture<RegTestFixture>
 		// 3. Create wasabi synchronizer service.
 		var httpClientFactory = RegTestFixture.IndexerHttpClientFactory;
 		var filterProvider = new WebApiFilterProvider(10_000, httpClientFactory, setup.EventBus);
-		using var synchronizer = Spawn("Synchronizer", Continuously(Synchronizer.CreateFilterGenerator(filterProvider, bitcoinStore, setup.EventBus)));
+		var (_, _, serviceLoop) = Continuously(Synchronizer.CreateFilterGenerator(filterProvider, bitcoinStore, setup.EventBus));
+		using var synchronizer = Spawn("Synchronizer", serviceLoop);
 
 		// 4. Create key manager service.
 		var keyManager = KeyManager.CreateNew(out _, password, network);

--- a/WalletWasabi.Tests/RegressionTests/SendTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/SendTests.cs
@@ -60,7 +60,8 @@ public class SendTests : IClassFixture<RegTestFixture>
 		// 3. Create wasabi synchronizer service.
 		var httpClientFactory = RegTestFixture.IndexerHttpClientFactory;
 		var filterProvider = new WebApiFilterProvider(10_000, httpClientFactory, setup.EventBus);
-		using var synchronizer = Spawn("Synchronizer", Continuously(Synchronizer.CreateFilterGenerator(filterProvider, bitcoinStore, setup.EventBus)));
+		var (_, _, serviceLoop) = Continuously(Synchronizer.CreateFilterGenerator(filterProvider, bitcoinStore, setup.EventBus));
+		using var synchronizer = Spawn("Synchronizer", serviceLoop);
 
 		// 4. Create key manager service.
 		var keyManager = KeyManager.CreateNew(out _, password, network);

--- a/WalletWasabi.Tests/RegressionTests/SpendUnconfirmedTxTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/SpendUnconfirmedTxTests.cs
@@ -61,7 +61,8 @@ public class SpendUnconfirmedTxTests : IClassFixture<RegTestFixture>
 		// 3. Create wasabi synchronizer service.
 		var httpClientFactory = RegTestFixture.IndexerHttpClientFactory;
 		var filterProvider = new WebApiFilterProvider(10_000, httpClientFactory, setup.EventBus);
-		using var synchronizer = Spawn("Synchronizer", Continuously(Synchronizer.CreateFilterGenerator(filterProvider, bitcoinStore, setup.EventBus)));
+		var (_, _, serviceLoop) = Continuously(Synchronizer.CreateFilterGenerator(filterProvider, bitcoinStore, setup.EventBus));
+		using var synchronizer = Spawn("Synchronizer", serviceLoop);
 
 		// 4. Create key manager service.
 		var keyManager = KeyManager.CreateNew(out _, password, network);

--- a/WalletWasabi.Tests/RegressionTests/WalletTests.cs
+++ b/WalletWasabi.Tests/RegressionTests/WalletTests.cs
@@ -48,7 +48,8 @@ public class WalletTests : IClassFixture<RegTestFixture>
 
 		// 2. Create wasabi synchronizer service.
 		var filterProvider = new WebApiFilterProvider(10_000, RegTestFixture.IndexerHttpClientFactory, setup.EventBus);
-		using var synchronizer = Spawn("Synchronizer", Continuously(Synchronizer.CreateFilterGenerator(filterProvider, bitcoinStore, setup.EventBus)));
+		var (_, _, serviceLoop) = Continuously(Synchronizer.CreateFilterGenerator(filterProvider, bitcoinStore, setup.EventBus));
+		using var synchronizer = Spawn("Synchronizer", serviceLoop);
 
 		// 3. Create key manager service.
 		var keyManager = KeyManager.CreateNew(out _, setup.Password, network);


### PR DESCRIPTION
This PR is for pausing the synchronizer after a problem with the node rpc is detected and for resuming it after the node rpc is available again and synchronized.