### PR TITLE
Application: Report exceptions

### DIFF
--- a/WalletWasabi.Daemon/Config/PersistentConfigManager.cs
+++ b/WalletWasabi.Daemon/Config/PersistentConfigManager.cs
@@ -97,7 +97,7 @@ public static class PersistentConfigManager
 			var defaultConfig = GetDefaultPersistentConfigByFileName(filePath);
 
 			ToFile(filePath, defaultConfig);
-			Logger.LogInfo($"{nameof(Config)} file has been deleted because it was corrupted. Recreated default version at path: `{filePath}`.");
+			Logger.LogInfo($"{nameof(Config)} file has been deleted because it was corrupted. Recreated default version at path: '{filePath}'.");
 			Logger.LogWarning(ex);
 			return defaultConfig;
 		}

--- a/WalletWasabi.Daemon/WasabiApplication.cs
+++ b/WalletWasabi.Daemon/WasabiApplication.cs
@@ -121,6 +121,8 @@ public class WasabiApplication
 			_ => throw new NotSupportedException($"Network '{networkName}' is not supported."),
 		};
 		var configFilePath = Path.Combine(Config.DataDir, configFileName);
+
+		Logger.LogInfo($"Loading config file '{configFilePath}'.");
 		var persistentConfig = PersistentConfigManager.LoadFile(configFilePath);
 
 		if (persistentConfig is PersistentConfig config)


### PR DESCRIPTION
On macOS, I'm getting an Avalonia-related exception when the wallet is starting. This is helpful to see any exception immediately in logs.