### PR TITLE
Remove cancel button and update coinjoin payments description

### DIFF
--- a/WalletWasabi.Fluent/Views/Wallets/CoinJoinPayment/CoinJoinPaymentsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/CoinJoinPayment/CoinJoinPaymentsView.axaml
@@ -12,11 +12,11 @@
                EnableBack="{Binding EnableBack}"
                EnableNext="True"
                NextContent="Done"
-               EnableCancel="{Binding EnableCancel}"
+               EnableCancel="False"
                IsBusy="{Binding IsBusy}"
                ScrollViewer.VerticalScrollBarVisibility="Auto">
     <ContentArea.Caption>
-      Payments queued here will be sent via coinjoin for enhanced privacy. Maximum 4 payments per round. Scheduled payments are not guaranteed to be fulfilled.
+      Payments queued here will be sent via coinjoin for enhanced privacy. Maximum 4 payments per round. This list is cleared when you close Wasabi.
     </ContentArea.Caption>
     <ContentArea.TopContent>
       <Button Content="Add Payment" Command="{Binding AddPaymentCommand}" HorizontalAlignment="Right" />


### PR DESCRIPTION
Removes a non-functioning cancel button from the coinjoin payments list (same concept as https://github.com/WalletWasabi/WalletWasabi/pull/14275)

This also updates the description to warn users that payment information that doesn't persist in between sessions. The removed text is somewhat redundant since the add payment screen already mentions that triggering coinjoin payments is not 100% reliable.