### PR TITLE
coinjoin payment dialog: add handcursor for add payment button

### DIFF
--- a/WalletWasabi.Fluent/Views/Wallets/CoinJoinPayment/CoinJoinPaymentsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/CoinJoinPayment/CoinJoinPaymentsView.axaml
@@ -19,7 +19,7 @@
       Payments queued here will be sent via coinjoin for enhanced privacy. Maximum 4 payments per round. Scheduled payments are not guaranteed to be fulfilled.
     </ContentArea.Caption>
     <ContentArea.TopContent>
-      <Button Content="Add Payment" Command="{Binding AddPaymentCommand}" HorizontalAlignment="Right" />
+      <Button Content="Add Payment" Command="{Binding AddPaymentCommand}" HorizontalAlignment="Right" Cursor="Hand"/>
     </ContentArea.TopContent>
 
     <DockPanel>


### PR DESCRIPTION
like every other button


<img width="175" height="101" alt="image" src="https://github.com/user-attachments/assets/2c37cc71-df44-49f6-bea3-3e876f5669cc" />

