### PR TITLE
Make currency input more strict and disallow input such as "testnet b…

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Userfacing/CurrencyInputTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Userfacing/CurrencyInputTests.cs
@@ -27,61 +27,64 @@ public class CurrencyInputTests
 	{
 		public CurrencyTestData()
 		{
-			Add("1", false, null);
+			Add("1", false, "1");
 			Add("1.", false, null);
-			Add("1.0", false, null);
+			Add("1.0", false, "1.0");
 			Add("", false, null);
-			Add("0.0", false, null);
-			Add("0", false, null);
+			Add("0.0", false, "0.0");
+			Add("0", false, "0");
 			Add("0.", false, null);
-			Add(".1", false, null);
+			Add(".1", true, "0.1");
 			Add(".", false, null);
-			Add(",", true, ".");
-			Add("20999999", false, null);
-			Add("2.1", false, null);
-			Add("1.11111111", false, null);
-			Add("1.00000001", false, null);
-			Add("20999999.9769", false, null);
+			Add(",", false, null);
+			Add("20999999", false, "20999999");
+			Add("2.1", false, "2.1");
+			Add("1.11111111", false, "1.11111111");
+			Add("1.00000001", false, "1.00000001");
+			Add("20999999.9769", false, "20999999.9769");
 			Add(" ", true, "");
 			Add("  ", true, "");
-			Add("abc", true, "");
-			Add("1a", true, "1");
-			Add("a1a", true, "1");
-			Add("a1 a", true, "1");
-			Add("a2 1 a", true, "21");
+			Add("abc", false, null);
+			Add("1a", false, null);
+			Add("a1a", false, null);
+			Add("a1 a", false, null);
+			Add("a2 1 a", false, null);
 			Add("2,1", true, "2.1");
 			Add("2٫1", true, "2.1");
 			Add("2٬1", true, "2.1");
 			Add("2⎖1", true, "2.1");
 			Add("2·1", true, "2.1");
 			Add("2'1", true, "2.1");
-			Add("2.1.", true, "2.1");
-			Add("2.1..", true, "2.1");
-			Add("2.1.,.", true, "2.1");
-			Add("2.1. . .", true, "2.1");
-			Add("2.1.1", true, "");
-			Add("2,1.1", true, "");
-			Add(".1.", true, ".1");
-			Add(",1", true, ".1");
-			Add("..1", true, ".1");
-			Add(".,1", true, ".1");
+			Add("2.1.", false, null);
+			Add("2.1..", false, null);
+			Add("2.1.,.", false, null);
+			Add("2.1. . .", false, null);
+			Add("2.1.1", false, null);
+			Add("2,1.1", false, null);
+			Add(".1.", false, null);
+			Add(",1", true, "0.1");
+			Add("..1", false, null);
+			Add(".,1", false, null);
 			Add("01", true, "1");
 			Add("001", true, "1");
 			Add("001.0", true, "1.0");
 			Add("001.00", true, "1.00");
 			Add("00", true, "0");
 			Add("0  0", true, "0");
-			Add("001.", true, "1.");
-			Add("00....1...,a", true, "");
-			Add("0...1.", true, "");
-			Add("1...1.", true, "");
-			Add("1.s.1...1.", true, "");
+			Add("001.", false, null);
+			Add("00....1...,a", false, null);
+			Add("0...1.", false, null);
+			Add("1...1.", false, null);
+			Add("1.s.1...1.", false, null);
 
 			// Negative values.
 			Add("-0", true, "0");
 			Add("-1", true, "1");
 			Add("-0.5", true, "0.5");
 			Add("-0,5", true, "0.5");
+
+			// Invalid values.
+			Add("tb1qzvp8n2k2v3k2v3k2v3k2v3k2v3k2v3k2v3k2v", false, null);
 		}
 	}
 
@@ -91,11 +94,11 @@ public class CurrencyInputTests
 		{
 			Add("1.000000000", true, "1.00000000");
 			Add("1.111111119", true, "1.11111111");
-			Add("20999999.97690001", false, null);
-			Add("30999999", false, null);
-			Add("303333333333333333999999", false, null);
-			Add("20999999.977", false, null);
-			Add("209999990.9769", false, null);
+			Add("20999999.97690001", false, "20999999.97690001");
+			Add("30999999", false, "30999999");
+			Add("303333333333333333999999", false, "303333333333333333999999");
+			Add("20999999.977", false, "20999999.977");
+			Add("209999990.9769", false, "209999990.9769");
 			Add("20999999.976910000000000", true, "20999999.97691000");
 			Add("209999990000000000.97000000000069", true, "209999990000000000.97000000");
 			Add("1.000000001", true, "1.00000000");

--- a/WalletWasabi/Userfacing/CurrencyInput.cs
+++ b/WalletWasabi/Userfacing/CurrencyInput.cs
@@ -24,15 +24,48 @@ public static partial class CurrencyInput
 	[GeneratedRegex(@"[\d.,٫٬⎖·\']")]
 	public static partial Regex RegexValidCharsOnly();
 
-	public static bool TryCorrectAmount(string original, [NotNullWhen(true)] out string? best)
+	[GeneratedRegex(@"^[\d]*[.,٫٬⎖·\']?[\d]+$")]
+	public static partial Regex RegexValidInput();
+
+	/// <summary>
+	/// Checks input amount value and attempts to correct it if it is not valid.
+	/// </summary>
+	/// <param name="original">Amount to check and correct if needed.</param>
+	/// <param name="correctedAmount">Amount representing <paramref name="original"/> if <paramref name="original"/> is deemed to be a valid amount string.</param>
+	/// <returns>
+	/// * True when original was modified and the result is stored in <paramref name="correctedAmount"/>.
+	/// * False when original was not modified, or if the original was invalid and could not be corrected.
+	/// </returns>
+	public static bool TryCorrectAmount(string original, [NotNullWhen(true)] out string? correctedAmount)
 	{
-		var corrected = original;
+		// No corrections was done.
+		if (original == "")
+		{
+			correctedAmount = null;
+			return false;
+		}
 
-		// Correct amount
-		Regex digitsOnly = new(@"[^\d.,٫٬⎖·\']");
+		var corrected = original.Replace(" ", "");
 
-		// Make it digits and .,٫٬⎖·\ only.
-		corrected = digitsOnly.Replace(corrected, "");
+		// String was trimmed, so it was changed.
+		if (corrected == "")
+		{
+			correctedAmount = "";
+			return true;
+		}
+
+		// Initial minus is allowed, and it is removed.
+		if (corrected.StartsWith('-'))
+		{
+			corrected = corrected[1..];
+		}
+
+		bool isValid = RegexValidInput().IsMatch(corrected);
+		if (!isValid)
+		{
+			correctedAmount = null;
+			return false;
+		}
 
 		// https://en.wikipedia.org/wiki/Decimal_separator
 		corrected = corrected.Replace(",", DecimalSeparator);
@@ -41,6 +74,11 @@ public static partial class CurrencyInput
 		corrected = corrected.Replace("⎖", DecimalSeparator);
 		corrected = corrected.Replace("·", DecimalSeparator);
 		corrected = corrected.Replace("'", DecimalSeparator);
+
+		if (corrected.StartsWith('.'))
+		{
+			corrected = "0" + corrected;
+		}
 
 		// Trim trailing dots except the last one.
 		if (corrected.EndsWith('.'))
@@ -87,17 +125,24 @@ public static partial class CurrencyInput
 
 		if (corrected != original)
 		{
-			best = corrected;
+			correctedAmount = corrected;
 			return true;
 		}
 
-		best = null;
+		correctedAmount = corrected;
 		return false;
 	}
 
 	public static bool TryCorrectBitcoinAmount(string original, [NotNullWhen(true)] out string? best)
 	{
-		TryCorrectAmount(original, out var corrected);
+		// It does not matter if the value was corrected or not.
+		_ = TryCorrectAmount(original, out var corrected);
+
+		if (corrected is null)
+		{
+			best = null;
+			return false;
+		}
 
 		// If the original value wasn't fixed, it's definitely not a null.
 		corrected ??= original;
@@ -115,7 +160,7 @@ public static partial class CurrencyInput
 			return true;
 		}
 
-		best = null;
+		best = corrected;
 		return false;
 	}
 }


### PR DESCRIPTION
…itcoin address"

Close #14341
Related to #14341 

This PR just attempts to modify parsing of currency inputs to be "reasonable". I find the current implementation too permissive.

This PR is an early draft. Not tested yet at all.

___

The reason why the testnet address mentioned [here](https://github.com/WalletWasabi/WalletWasabi/issues/14341#issue-3925517869) is converted to an amount is this line:

https://github.com/WalletWasabi/WalletWasabi/blob/81c66d8cc4d28c8acf66878e1c22f3937345e4c1/WalletWasabi/Userfacing/CurrencyInput.cs#L35

Meaning,

`tb1qzvp8n2k2v3k2v3k2v3k2v3k2v3k2v3k2v3k2v`

is converted to

`  1    8 2 2 3 2 3 2 3 2 3 2 3 2 3 2 3 2 `

and that is converted to

`182232323232323232`

Wild. :)

I opened #14368 where I try to make the parser more strict:

* allow only digits and various separators
* do not allow a-z characters (and other non-allowed characters)