### PR TITLE
Display fee rate with proper precision in UI

### DIFF
--- a/WalletWasabi.Fluent/Converters/FeeRateConverter.cs
+++ b/WalletWasabi.Fluent/Converters/FeeRateConverter.cs
@@ -1,0 +1,9 @@
+using Avalonia.Data.Converters;
+
+namespace WalletWasabi.Fluent.Converters;
+
+public static class FeeRateConverters
+{
+	public static FuncValueConverter<decimal, string> FeeRateConverter { get; } =
+		new(feeRate => $"{feeRate:0.0#####} sat/vByte");
+}

--- a/WalletWasabi.Fluent/Views/Wallets/Home/History/Details/CoinJoinDetailsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/History/Details/CoinJoinDetailsView.axaml
@@ -71,7 +71,7 @@
                      Label="Fee Rate"
                      CopyableContent="{Binding FeeRate.SatoshiPerByte}">
         <PrivacyContentControl>
-         <TextBlock Text="{Binding FeeRate.SatoshiPerByte, StringFormat='{}{0:0.0#####} sat/vByte'}" />
+         <TextBlock Text="{Binding FeeRate.SatoshiPerByte, Converter={x:Static conv:FeeRateConverters.FeeRateConverter}}" />
         </PrivacyContentControl>
       </PreviewItem>
 

--- a/WalletWasabi.Fluent/Views/Wallets/Home/History/Details/TransactionDetailsView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Home/History/Details/TransactionDetailsView.axaml
@@ -74,7 +74,7 @@
                      Label="Fee Rate"
                      CopyableContent="{Binding FeeRate.SatoshiPerByte}">
         <PrivacyContentControl>
-          <TextBlock Text="{Binding FeeRate.SatoshiPerByte, StringFormat='{}{0:0.0#####} sat/vByte'}" />
+          <TextBlock Text="{Binding FeeRate.SatoshiPerByte, Converter={x:Static conv:FeeRateConverters.FeeRateConverter}}"/>
         </PrivacyContentControl>
       </PreviewItem>
 

--- a/WalletWasabi.Fluent/Views/Wallets/Send/SendFeeView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Send/SendFeeView.axaml
@@ -3,6 +3,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:vm="using:WalletWasabi.Fluent.ViewModels.Wallets.Send"
+             xmlns:c="using:WalletWasabi.Fluent.Converters"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:CompileBindings="True"
              x:DataType="vm:SendFeeViewModel"
@@ -220,7 +221,12 @@
                 <Setter Property="FontSize" Value="{StaticResource FontSizeH8}" />
               </Style>
             </StackPanel.Styles>
-            <TextBlock Text="{Binding CurrentSatoshiPerByte, Mode=OneWay, StringFormat='Fee Rate: {0:0.0#####} sat/vByte'}" />
+            <TextBlock>
+            </TextBlock>
+            <TextBlock>
+              <Run Text="Fee Rate:"/>
+              <Run Text="{Binding CurrentSatoshiPerByte, Mode=OneWay, Converter={x:Static c:FeeRateConverters.FeeRateConverter}}" />
+            </TextBlock>
             <TextBlock Text="{Binding CurrentConfirmationTargetString, Mode=OneWay, StringFormat='Estimated Confirmation Time: \{0\}'}" />
           </StackPanel>
         </Panel>

--- a/WalletWasabi.Fluent/Views/Wallets/Send/TransactionSummary.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Send/TransactionSummary.axaml
@@ -136,7 +136,7 @@
         <PreviewItem Icon="{StaticResource paper_cash_regular}"
                      Label="Fee Rate"
                      CopyableContent="{Binding FeeRate.SatoshiPerByte}">
-         <TextBlock Text="{Binding FeeRate.SatoshiPerByte, StringFormat='{}{0:0.0#####} sat/vByte'}" />
+         <TextBlock Text="{Binding FeeRate.SatoshiPerByte, Mode=OneWay, Converter={x:Static converters:FeeRateConverters.FeeRateConverter}}" />
         </PreviewItem>
       </StackPanel>
     </DockPanel>


### PR DESCRIPTION
close https://github.com/WalletWasabi/WalletWasabi/issues/14373

Update fee rate formatting across all UI components to show at least one decimal place and up to six decimal places. This provides better precision for users while maintaining readability.

Format changed from {0} or {0:0.##} to {0:0.0#####}

Files updated:
- TransactionDetailsView: Shows fee rate in transaction details
- CoinJoinDetailsView: Shows fee rate in coinjoin transaction details
- SendFeeView: Shows current fee rate during transaction creation
- TransactionSummary: Shows fee rate in send transaction summary