### PR TITLE
Auto-detect Tails and Whonix to set Tor Connect Only mode

### DIFF
--- a/WalletWasabi.Daemon/Config/PersistentConfigManager.cs
+++ b/WalletWasabi.Daemon/Config/PersistentConfigManager.cs
@@ -126,9 +126,14 @@ public static class PersistentConfigManager
 	{
 		// On Tails and Whonix, Tor is already running system-wide
 		// We should only connect to it, not start our own instance
-		if (PlatformInformation.MustUseSystemWideTorProcess())
+		if (PlatformInformation.IsTailsOS())
 		{
-			Logger.LogInfo("Detected Tails or Whonix OS. Setting Tor mode to 'Connect Only' by default.");
+			Logger.LogInfo("Detected Tails operating system. Setting Tor mode to 'Connect Only' by default.");
+			return "EnabledOnlyRunning";
+		}
+		else if (PlatformInformation.IsWhonix())
+		{
+			Logger.LogInfo("Detected Whonix operating system. Setting Tor mode to 'Connect Only' by default.");
 			return "EnabledOnlyRunning";
 		}
 

--- a/WalletWasabi/Helpers/EnvironmentHelpers.cs
+++ b/WalletWasabi/Helpers/EnvironmentHelpers.cs
@@ -301,7 +301,7 @@ public static class PlatformInformation
 
 	private static bool TryGetLinuxOSRelease([NotNullWhen(true)] out string? content)
 	{
-		if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) &&  File.Exists("/etc/os-release"))
+		if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux) && File.Exists("/etc/os-release"))
 		{
 			try
 			{
@@ -310,7 +310,7 @@ public static class PlatformInformation
 			}
 			catch (Exception ex)
 			{
-				Logger.LogDebug($"Failed to read /etc/os-release for Tails detection: {ex.Message}");
+				Logger.LogDebug($"Failed to read /etc/os-release for operating system detection: {ex.Message}");
 			}
 		}
 
@@ -318,17 +318,14 @@ public static class PlatformInformation
 		return false;
 	}
 
-	private static bool IsTailsOS() =>
+	public static bool IsTailsOS() =>
 		TryGetLinuxOSRelease(out var osReleaseContent) && (
 			osReleaseContent.Contains("ID=tails", StringComparison.OrdinalIgnoreCase) ||
 			osReleaseContent.Contains("NAME=\"Tails\"", StringComparison.OrdinalIgnoreCase));
 
-	private static bool IsWhonix() =>
+	public static bool IsWhonix() =>
 		TryGetLinuxOSRelease(out var osReleaseContent) && (
 			osReleaseContent.Contains("ID=whonix", StringComparison.OrdinalIgnoreCase) ||
 			osReleaseContent.Contains("NAME=\"Whonix\"", StringComparison.OrdinalIgnoreCase) ||
 			osReleaseContent.Contains("ID_LIKE=debian whonix", StringComparison.OrdinalIgnoreCase));
-
-	public static bool MustUseSystemWideTorProcess() =>
-		IsTailsOS() || IsWhonix();
 }


### PR DESCRIPTION
Close: https://github.com/WalletWasabi/WalletWasabi/issues/14390

Detect privacy-focus operating systems Tails OS and Whonix to set the correct Tor Mode. 