### PR TITLE
Fix `CoreConfigTests.cs`

### DIFF
--- a/WalletWasabi.Tests/BitcoinCore/Configuration/CoreConfig.cs
+++ b/WalletWasabi.Tests/BitcoinCore/Configuration/CoreConfig.cs
@@ -34,7 +34,8 @@ public class CoreConfig
 		return myDic;
 	}
 
-	public override string ToString() => $"{Guard.Correct(string.Join(Environment.NewLine, _lines))}{Environment.NewLine}"; // Good practice to end with a newline.
+	public override string ToString() =>
+		$"{Guard.Correct(string.Join("\n", _lines))}\n"; // Good practice to end with a newline.
 
 	public bool AddOrUpdate(string configString)
 	{

--- a/WalletWasabi.Tests/UnitTests/BitcoinCore/CoreConfigTests.cs
+++ b/WalletWasabi.Tests/UnitTests/BitcoinCore/CoreConfigTests.cs
@@ -10,9 +10,9 @@ public class CoreConfigTests
 	public void RemovesEmptyDuplications()
 	{
 		var configStringBuilder = new StringBuilder("foo=bar");
-		configStringBuilder.Append(Environment.NewLine);
-		configStringBuilder.Append(Environment.NewLine);
-		configStringBuilder.Append(Environment.NewLine);
+		configStringBuilder.Append('\n');
+		configStringBuilder.Append('\n');
+		configStringBuilder.Append('\n');
 		configStringBuilder.Append("bar=bar");
 
 		var config = new CoreConfig();
@@ -36,9 +36,9 @@ public class CoreConfigTests
 			foo = bar
 			""";
 
-		testConfig += Environment.NewLine;
-		testConfig += Environment.NewLine;
-		testConfig += Environment.NewLine;
+		testConfig += "\n";
+		testConfig += "\n";
+		testConfig += "\n";
 		testConfig +=
 			"""
 			 foo = bar


### PR DESCRIPTION
`CoreConfigTests` are not trully multiplatform as the tests fail on Windows. This PR attempts to fix it.

I verified on a Windows box that bitcoin.conf with `\n` (not `\r\n`) works OK.

```
cd WalletWasabi\WalletWasabi.Tests\BundledApps\Binaries\win-x64
bitcoind.exe -datadir=data -conf="bitcoin.conf" -softwareexpiry=0
```

where `data/bitcoin.conf` contains

```
rpcuser=myuser                     # \n here
rpcpassword=mypassword    # \n here
```