### PR TITLE
fix: Unsigned SHA256SUMS controls auto-update installer verification in ReleaseDownloader

### DIFF
--- a/WalletWasabi/Services/UpdateManager.cs
+++ b/WalletWasabi/Services/UpdateManager.cs
@@ -186,8 +186,9 @@ public static class ReleaseDownloader
 
 		async Task<string> GetExpectedInstallerHashAsync()
 		{
-			var lines = await File.ReadAllLinesAsync(sha256SumsTask.Result, cancellationToken).ConfigureAwait(false);
+			var lines = await File.ReadAllLinesAsync(sha256SumsAscTask.Result, cancellationToken).ConfigureAwait(false);
 			var s = lines.Select(l => l.Split("  ./", StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries))
+				.Where(a => a.Length == 2)
 				.Select(a => (Hash: a[0], FileName: a[1]))
 				.FirstOrDefault(a => a.FileName == installerFileName)
 				.Hash ?? throw new InvalidOperationException($"{installerFileName} was not found.");


### PR DESCRIPTION
Closes #14408

## Summary

Automated security fixes for 1 findings.

## Fixes

| Title | Severity | File | Confidence | Explanation |
| --- | --- | --- | --- | --- |
| Unsigned SHA256SUMS controls auto-update installer verification in ReleaseDownloader | Critical | `WalletWasabi/Services/UpdateManager.cs` | high | The vulnerability is that `GetExpectedInstallerHashAsync()` reads installer hashes from the unsigned `SHA256SUMS` file, while the signature verification authenticates only `SHA256SUMS.asc`. An attacker could substitute a malicious installer with a matching unsigned `SHA256SUMS` while leaving the signed `.asc` file untouched.  The fix makes two changes in `GetExpectedInstallerHashAsync()`: 1. Changed `sha256SumsTask.Result` to `sha256SumsAscTask.Result` — reads hashes from the signature-verified `.asc` file instead of the unsigned raw file. 2. Added `.Where(a => a.Length == 2)` filter before the `.Select(a => (Hash: a[0], FileName: a[1]))` — this is necessary because the `.asc` file contains PGP clear-sign headers/footers (e.g., `-----BEGIN PGP SIGNED MESSAGE-----`, `Hash: SHA256`, signature blocks) that would cause IndexOutOfRangeException when trying to access `a[1]` on non-hash lines. |

## Caveats
- The SHA256SUMS file is still downloaded but no longer used for hash extraction. It could be removed from the download set, but that would be a larger change beyond the vulnerability scope.
- The existing test should still pass because it provides both SHA256SUMS and SHA256SUMS.asc with the same hash content, and the .asc file's PGP header lines will be correctly filtered out by the new .Where(a => a.Length == 2) clause.

## Verification Checklist

- [ ] Review the code change
- [ ] Run tests to verify no regression
- [x] Verify the vulnerability is addressed — *already verified by Cerberus Sentinel*

---
*Created by [Cerberus](https://github.com/Donjon-Cerberus) Merlin*
