### PR TITLE
update WalletBackupType options to match & add help text

### DIFF
--- a/WalletWasabi.Fluent/ViewModels/AddWallet/Create/WalletBackupTypeViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/AddWallet/Create/WalletBackupTypeViewModel.cs
@@ -46,7 +46,7 @@ public partial class WalletBackupTypeViewModel : RoutableViewModel
 					new WalletBackupType.RecoveryWords(
 						new WalletBackupTypeOptions(
 							Description: "Single mnemonic phrase (BIP39)",
-							HelpText: "Use a backup that was exists of one set of words.")),
+							HelpText: "Use a backup generated from a set of 12, 18, or 24 words.")),
 				];
 
 				break;


### PR DESCRIPTION
closes https://github.com/WalletWasabi/WalletWasabi/issues/14423

- match order for creation and recovery
- add HelpText

### PR
**creation**
<img width="789" height="679" alt="Screenshot from 2026-03-23 15-51-39" src="https://github.com/user-attachments/assets/d0149084-03a0-4de3-84db-e29051ca6a8c" />


**recovery**
<img width="789" height="679" alt="Screenshot from 2026-03-23 15-51-48" src="https://github.com/user-attachments/assets/195a4099-75d4-418d-882c-2050a633c276" />

