### PR TITLE
Remove `TreatWarningsAsErrors`

### DIFF
--- a/WalletWasabi.Client/WalletWasabi.Client.csproj
+++ b/WalletWasabi.Client/WalletWasabi.Client.csproj
@@ -3,7 +3,6 @@
 	<PropertyGroup>
 		<DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
 		<NoWarn>1701;1702;1705;1591;1573;CA1031;CA1822</NoWarn>
-		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 		<RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
 		<DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
 		<PathMap>$(MSBuildProjectDirectory)\=WalletWasabi.Client</PathMap>

--- a/WalletWasabi.Daemon/WalletWasabi.Daemon.csproj
+++ b/WalletWasabi.Daemon/WalletWasabi.Daemon.csproj
@@ -2,7 +2,6 @@
 
 	<PropertyGroup>
 		<NoWarn>1701;1702;1705;1591;1573;CA1031;CA1822</NoWarn>
-		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 		<RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
 		<DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
 		<PathMap>$(MSBuildProjectDirectory)\=WalletWasabi.Daemon</PathMap>

--- a/WalletWasabi.Fluent.Desktop/WalletWasabi.Fluent.Desktop.csproj
+++ b/WalletWasabi.Fluent.Desktop/WalletWasabi.Fluent.Desktop.csproj
@@ -3,7 +3,6 @@
 	<PropertyGroup>
 		<DisableImplicitNamespaceImports>true</DisableImplicitNamespaceImports>
 		<NoWarn>1701;1702;1705;1591;1573;CA1031;CA1822</NoWarn>
-		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
 		<RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
 		<DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
 		<RuntimeIdentifiers>win-x64;linux-x64;linux-arm64;osx-x64;osx-arm64</RuntimeIdentifiers>


### PR DESCRIPTION
This PR removes `<TreatWarningsAsErrors>` because

1. UX for developers is not good. For each error, one has to figure out if it is a real compilation error or if it is a warning (which can be important but often it's harmless, such as wrong file namespace).
2. It's not consistently used in all projects. 

In my opinion, it would be for the best to have warnings as warnings, errors as errors and strive for zero warnings in the long term. Ideally, in some enforced way (build breaks if there is a warning).