### PR TITLE
Fix Loopback bug with Tor when the RPC URI is localhost

### DIFF
--- a/WalletWasabi.Client/Global.cs
+++ b/WalletWasabi.Client/Global.cs
@@ -217,10 +217,11 @@ public class Global
 		
 		// If the RPC URI is a loopback (i.e., localhost)
 		// then we are bypassing Tor
-		if (!new Uri(bitcoinRpcUri).IsLoopback){
+		var isBitcoinRpcLocal = new Uri(bitcoinRpcUri).IsLoopback;
+		if (!isBitcoinRpcLocal)
+		{
 			internalRpcClient.HttpClient =
 							ExternalSourcesHttpClientFactory.CreateClient("long-live-rpc-connection");
-
 		}
 		
 		return new RpcClientBase(internalRpcClient);


### PR DESCRIPTION
This PR fixes a critical loopback bug when the user tries to connect to their own node via RPC (in localhost). With the recent PR https://github.com/WalletWasabi/WalletWasabi/pull/14443, it always uses Tor to connect with the RPC node. 

To reproduce the problem, try running a testnet4 node, clone [WalletWasabi](https://github.com/WalletWasabi/WalletWasabi.git), and run:
```
dotnet run --network=testnet4 --bitcoinrpcendpoint=http://localhost:48332 --bitcoinrpccredentialstring=user:pass
```
Tor tries to connect to localhost, and Wasabi crashes. 

The solution is to check if the URI is a loopback. 