### PR TITLE
Fix ArgumentNullException in RoundStateRequest decoder

### DIFF
--- a/WalletWasabi/Serialization/Coordination.cs
+++ b/WalletWasabi/Serialization/Coordination.cs
@@ -563,7 +563,7 @@ public static partial class Decode
 
 	private static Decoder<RoundStateRequest> RoundStateRequest =>
 		Object(get => new RoundStateRequest(
-			get.Required("RoundCheckpoints", Array(RoundStateCheckpoint)).ToImmutableList()
+			(get.Required("RoundCheckpoints", Array(RoundStateCheckpoint)) ?? []).ToImmutableList()
 		));
 
 	private static  Decoder<RoundStateResponse> RoundStateResponse =>


### PR DESCRIPTION
## Summary
- Fixes an `ArgumentNullException` in the `RoundStateRequest` decoder when clients send malformed JSON (missing or invalid `RoundCheckpoints` field)
- When `get.Required()` fails it returns `null`, and the subsequent `.ToImmutableList()` call throws before the decoder's error handling can return a proper failure result
- Null-coalesce to an empty array so the error propagates gracefully instead of throwing an unhandled exception

Closes #14448

## Test plan
- [x] Existing `RoundStateRequestSerialization` test passes
- [x] Verify coordinator no longer logs `ArgumentNullException` for malformed status requests

## New log of error:

> 2026-03-28 19:20:41.486 [ 6] ERR | WasabiJsonInputFormatter.cs:34 | Object does not contain a property called 'RoundCheckpoints'
> 2026-03-28 19:21:01.383 [ 7] ERR | WasabiJsonInputFormatter.cs:34 | Object does not contain a property called 'RoundCheckpoints'