### PR TITLE
TorSettings: Snowflake should be mapped to lyrebird

### DIFF
--- a/WalletWasabi/Tor/TorSettings.cs
+++ b/WalletWasabi/Tor/TorSettings.cs
@@ -213,7 +213,7 @@ public class TorSettings
 				{
 					"obfs4" => "lyrebird", // obfs4 was renamed to lyrebird.
 					"webtunnel" => "webtunnel-client",
-					"snowflake" => "snowflake-client",
+					"snowflake" => "lyrebird",
 					_ => throw new NotSupportedException($"Unknown Tor pluggable transport '{plugin}'."),
 				};
 


### PR DESCRIPTION
Close #14450

It appears that `snowflake-client` is no longer distributed with Tor Browser (see https://gitlab.torproject.org/tpo/applications/tor-browser-build/-/issues/41425). `lyrebird` seems to handle snowflakes now.

I executed `Contrib/BundledApps/upgrade-tor.sh 16.0a5` and checked `TorBrowser\Tor\PluggableTransports` folders and there is no `snowflake-client`(.exe) file. Only `lyrebird`. This makes me think that the change is safe. 

### Test

Change `YOUR-USER` to proper user name:

```
dotnet run -- --torfolder="C:\Users\YOUR-USER\Desktop\Tor Browser\Browser\TorBrowser\Tor" --torbridges="snowflake 192.0.2.3:80 2B280B23E1107BB62ABFC40DDCC8824814F80A72 fingerprint=2B280B23E1107BB62ABFC40DDCC8824814F80A72 url=https://1098762253.rsc.cdn77.org/ fronts=app.datapacket.com,www.datapacket.com ice=stun:stun.epygi.com:3478,stun:stun.uls.co.za:3478,stun:stun.voipgate.com:3478,stun:stun.mixvoip.com:3478,stun:stun.nextcloud.com:3478,stun:stun.bethesda.net:3478,stun:stun.nextcloud.com:443 utls-imitate=hellorandomizedalpn;snowflake 192.0.2.4:80 8838024498816A039FCBBAB14E6F40A0843051FA fingerprint=8838024498816A039FCBBAB14E6F40A0843051FA url=https://1098762253.rsc.cdn77.org/ fronts=app.datapacket.com,www.datapacket.com ice=stun:stun.epygi.com:3478,stun:stun.uls.co.za:3478,stun:stun.voipgate.com:3478,stun:stun.mixvoip.com:3478,stun:stun.nextcloud.com:3478,stun:stun.bethesda.net:3478,stun:stun.nextcloud.com:443 utls-imitate=hellorandomizedalpn"
```

The wallet should start up.