### PR TITLE
TorProcessManagerTests: Remove `Mock<*>` instances

### DIFF
--- a/WalletWasabi.Tests/UnitTests/Tor/TorProcessManagerTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Tor/TorProcessManagerTests.cs
@@ -1,4 +1,3 @@
-using Moq;
 using System.Diagnostics;
 using System.IO;
 using System.IO.Pipelines;
@@ -25,46 +24,38 @@ public class TorProcessManagerTests
 	{
 		using CancellationTokenSource timeoutCts = new(TimeSpan.FromMinutes(2));
 
-		// Test parameter: Simulate that Tor process crashes after two seconds.
-		TimeSpan torProcessCrashPeriod = TimeSpan.FromSeconds(2);
-
 		// Tor settings.
 		string dataDir = Path.Combine("temp", "tempDataDir");
 		string distributionFolder = "tempDistributionDir";
 		TorSettings settings = new(dataDir, distributionFolder, terminateOnExit: true, owningProcessId: 7);
 
-		// Mock Tor process.
-		Mock<ProcessAsync> mockProcess = new(MockBehavior.Strict, new ProcessStartInfo());
-		mockProcess.Setup(p => p.WaitForExitAsync(It.IsAny<CancellationToken>()))
-			.Returns((CancellationToken cancellationToken) => Task.Delay(torProcessCrashPeriod, cancellationToken));
-		mockProcess.Setup(p => p.Dispose());
+		// Create test manager with predefined behavior.
+		TestTorProcessManager manager = new(settings, new EventBus())
+		{
+			// Simulate that Tor process crashes after two seconds.
+			WaitForTorProcessDelay = TimeSpan.FromSeconds(2),
+			IsTorRunningAsyncResult = false,
+			EnsureRunningAsyncResult = true,
+			InitTorControlAsyncResult = new TorControlClient(pipeReader: new Pipe().Reader, pipeWriter: new Pipe().Writer)
+		};
 
-		// Mock TorProcessManager.
-		Mock<TorProcessManager> mockTorProcessManager = new(MockBehavior.Strict, settings, new EventBus()) { CallBase = true };
-		mockTorProcessManager.Setup(c => c.IsTorRunningAsync(It.IsAny<CancellationToken>()))
-			.ReturnsAsync(false);
-		mockTorProcessManager.Setup(c => c.StartProcess(It.IsAny<string>()))
-			.Returns(mockProcess.Object);
-		mockTorProcessManager.Setup(c => c.EnsureRunningAsync(It.IsAny<ProcessAsync>(), It.IsAny<CancellationToken>()))
-			.ReturnsAsync(true);
-		mockTorProcessManager.SetupSequence(c => c.InitTorControlAsync(It.IsAny<CancellationToken>()))
-			.ReturnsAsync(() => new TorControlClient(pipeReader: new Pipe().Reader, pipeWriter: new Pipe().Writer)) // (1)
-			.ThrowsAsync(new OperationCanceledException()); // (2)
-
-		await using (TorProcessManager manager = mockTorProcessManager.Object)
+		await using (manager)
 		{
 			// No exception is expected here.
 			(CancellationToken ct1, TorControlClient? client1) = await manager.StartAsync(timeoutCts.Token);
 
-			// Wait for the Tor process crash (see (1)).
+			// Wait for the Tor process crash.
 			await ct1.WhenCanceled().WaitAsync(timeoutCts.Token);
 
-			// Wait until TorProcessManager is stopped (see (2)).
-			await Assert.ThrowsAnyAsync<OperationCanceledException>(async () => await manager.WaitForNextAttemptAsync(timeoutCts.Token).ConfigureAwait(false));
+			// On second attempt, InitTorControlAsync should throw.
+			manager.InitTorControlAsyncException = new OperationCanceledException();
+
+			// Wait until TorProcessManager is stopped.
+			await Assert.ThrowsAnyAsync<OperationCanceledException>(async () =>
+				await manager.WaitForNextAttemptAsync(timeoutCts.Token).ConfigureAwait(false));
 		}
 
-		mockTorProcessManager.Verify(c => c.StartProcess(It.IsAny<string>()), Times.Exactly(2));
-		mockTorProcessManager.VerifyAll();
+		Assert.Equal(2, manager.StartProcessCallCount);
 	}
 
 	/// <summary>
@@ -83,23 +74,96 @@ public class TorProcessManagerTests
 		string distributionFolder = "tempDistributionDir";
 		TorSettings settings = new(dataDir, distributionFolder, terminateOnExit: true, owningProcessId: 7);
 
-		Mock<TorProcessManager> mockTorProcessManager = new(MockBehavior.Strict, settings, new EventBus()) { CallBase = true };
-		mockTorProcessManager.Setup(c => c.IsTorRunningAsync(It.IsAny<CancellationToken>()))
-			.ReturnsAsync(true);
-
-		mockTorProcessManager.Setup(c => c.GetTorProcesses())
-			.Returns(runningTorOsProcesses == 0 ? [] : new[] { new Process() /* Dummy process */ });
-
-		// Cookie file is stored in the profile of that different user, not ours.
-		mockTorProcessManager.Setup(c => c.InitTorControlAsync(It.IsAny<CancellationToken>()))
-			.ThrowsAsync(new TorControlException("Cookie file does not exist."));
-
-		await using (TorProcessManager torProcessManager = mockTorProcessManager.Object)
+		// Create test manager that simulates Tor running by different user.
+		TestTorProcessManager manager = new(settings, new EventBus())
 		{
-			NotSupportedException ex = await Assert.ThrowsAsync<NotSupportedException>(async () => await torProcessManager.StartAsync(timeoutCts.Token).ConfigureAwait(false));
+			IsTorRunningAsyncResult = true,
+			GetTorProcessesResult = runningTorOsProcesses == 0 ? [] : new[] { new Process() /* Dummy process */ },
+			InitTorControlAsyncException = new TorControlException("Cookie file does not exist.")
+		};
+
+		await using (manager)
+		{
+			NotSupportedException ex = await Assert.ThrowsAsync<NotSupportedException>(async () => await manager.StartAsync(timeoutCts.Token).ConfigureAwait(false));
 			Assert.Equal(TorProcessManager.TorProcessStartedByDifferentUser, ex.Message);
 		}
+	}
+}
 
-		mockTorProcessManager.VerifyAll();
+file class TestTorProcessManager : TorProcessManager
+{
+	public int StartProcessCallCount { get; private set; }
+
+	public TimeSpan? WaitForTorProcessDelay { get; set; }
+	public bool? IsTorRunningAsyncResult { get; set; }
+	public bool? EnsureRunningAsyncResult { get; set; }
+	public Process[]? GetTorProcessesResult { get; set; }
+	public TorControlClient? InitTorControlAsyncResult { get; set; }
+	public Exception? InitTorControlAsyncException { get; set; }
+
+	public TestTorProcessManager(TorSettings settings, EventBus eventBus)
+		: base(settings, eventBus)
+	{
+	}
+
+	internal override ProcessAsync StartProcess(string arguments)
+	{
+		StartProcessCallCount++;
+		return base.StartProcess(arguments);
+	}
+
+	internal override async Task WaitForTorProcessExitAsync(ProcessAsync process, CancellationToken cancellationToken)
+	{
+		if (WaitForTorProcessDelay is not null)
+		{
+			await Task.Delay(WaitForTorProcessDelay.Value, cancellationToken);
+			return;
+		}
+
+		await base.WaitForTorProcessExitAsync(process, cancellationToken);
+	}
+
+	public override async Task<bool> IsTorRunningAsync(CancellationToken cancellationToken)
+	{
+		if (IsTorRunningAsyncResult is not null)
+		{
+			return IsTorRunningAsyncResult.Value;
+		}
+
+		return await base.IsTorRunningAsync(cancellationToken).ConfigureAwait(false);
+	}
+
+	internal override async Task<bool> EnsureRunningAsync(ProcessAsync process, CancellationToken cancellationToken)
+	{
+		if (EnsureRunningAsyncResult.HasValue)
+		{
+			return EnsureRunningAsyncResult.Value;
+		}
+
+		return await base.EnsureRunningAsync(process, cancellationToken).ConfigureAwait(false);
+	}
+
+	internal override Process[] GetTorProcesses()
+	{
+		if (GetTorProcessesResult is not null)
+		{
+			return GetTorProcessesResult;
+		}
+
+		return base.GetTorProcesses();
+	}
+
+	internal override async Task<TorControlClient> InitTorControlAsync(CancellationToken cancellationToken)
+	{
+		if (InitTorControlAsyncException is not null)
+		{
+			throw InitTorControlAsyncException;
+		}
+		else if (InitTorControlAsyncResult is not null)
+		{
+			return InitTorControlAsyncResult;
+		}
+
+		return await base.InitTorControlAsync(cancellationToken).ConfigureAwait(false);
 	}
 }

--- a/WalletWasabi/Tor/TorProcessManager.cs
+++ b/WalletWasabi/Tor/TorProcessManager.cs
@@ -316,7 +316,7 @@ public class TorProcessManager : IAsyncDisposable
 					_tcs.SetResult((cts.Token, controlClient));
 				}
 
-				await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
+				await WaitForTorProcessExitAsync(process, cancellationToken).ConfigureAwait(false);
 
 				Logger.LogDebug("Tor process exited.");
 			}
@@ -395,6 +395,12 @@ public class TorProcessManager : IAsyncDisposable
 				}
 			}
 		}
+	}
+
+	/// <remarks>The method exist to avoid mocking <see cref="Process"/>. Do not call the method outside this class.</remarks>
+	internal virtual async Task WaitForTorProcessExitAsync(ProcessAsync process, CancellationToken cancellationToken)
+	{
+		await process.WaitForExitAsync(cancellationToken).ConfigureAwait(false);
 	}
 
 	private void OnTorStop(bool willWaitForTorRestart, Exception? exception, CancellationTokenSource torStoppedCts, CancellationToken globalCancellationToken)


### PR DESCRIPTION
Removes a few more `Mock<*>` instances. Two more remains.