### PR TITLE
CoinJoinCoinSelectionTests: Remove use of `Mock`

### DIFF
--- a/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
+++ b/WalletWasabi.Tests/Helpers/WabiSabiFactory.cs
@@ -371,9 +371,7 @@ public static class WabiSabiFactory
 	public static (Prison, ChannelReader<Offender>) CreateObservablePrison()
 	{
 		var channel = Channel.CreateUnbounded<Offender>();
-		var prison = new Prison(
-			Enumerable.Empty<Offender>(),
-			channel.Writer);
+		var prison = new Prison([], channel.Writer);
 		return (prison, channel.Reader);
 	}
 

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/CoinJoinCoinSelectionTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/CoinJoinCoinSelectionTests.cs
@@ -1,8 +1,6 @@
 using System.Linq;
-using Moq;
 using NBitcoin;
 using WabiSabi.Crypto.Randomness;
-using WalletWasabi.Blockchain.Analysis;
 using WalletWasabi.Blockchain.Keys;
 using WalletWasabi.Blockchain.TransactionOutputs;
 using WalletWasabi.Helpers;
@@ -29,7 +27,7 @@ public class CoinJoinCoinSelectionTests
 
 		var coinJoinCoinSelector = new CoinJoinCoinSelector(consolidationMode: false, anonScoreTarget: 10, semiPrivateThreshold: 0, generator);
 		var coins = coinJoinCoinSelector.SelectCoinsForRound(
-			coins: Enumerable.Empty<SmartCoin>(),
+			coins: [],
 			CreateUtxoSelectionParameters(),
 			liquidityClue: Constants.MaximumNumberOfBitcoinsMoney);
 
@@ -49,7 +47,7 @@ public class CoinJoinCoinSelectionTests
 			.Select(i => BitcoinFactory.CreateSmartCoin(BitcoinFactory.CreateHdPubKey(km, isInternal: true), Money.Coins(1m), anonymitySet: AnonymitySet + 1))
 			.ToList();
 
-		// We gotta make sure the distance from external keys is sufficient.
+		// Make sure the distance from external keys is sufficient.
 		foreach (var sc in coinsToSelectFrom)
 		{
 			var sci = BitcoinFactory.CreateSmartCoin(BitcoinFactory.CreateHdPubKey(km, isInternal: true), Money.Coins(1m), anonymitySet: AnonymitySet + 1);
@@ -266,7 +264,7 @@ public class CoinJoinCoinSelectionTests
 		var utxoSelectionParameter = CreateUtxoSelectionParameters();
 		coinsToSelectFrom.Add(BitcoinFactory.CreateSmartCoin(BitcoinFactory.CreateHdPubKey(km, isInternal: true), utxoSelectionParameter.AllowedInputAmounts.Min - Money.Satoshis(1), anonymitySet: AnonymitySet - 1));
 
-		// We gotta make sure the distance from external keys is sufficient.
+		// Make sure the distance from external keys is sufficient.
 		foreach (var sc in coinsToSelectFrom)
 		{
 			var sci = BitcoinFactory.CreateSmartCoin(BitcoinFactory.CreateHdPubKey(km, isInternal: true), Money.Coins(1m), anonymitySet: AnonymitySet + 1);
@@ -287,18 +285,18 @@ public class CoinJoinCoinSelectionTests
 
 	private static CoinJoinCoinSelectorRandomnessGenerator CreateSelectorGenerator(int inputTarget, int? sameTxAllowance = null)
 	{
-		WasabiRandom rng = InsecureRandom.Instance;
-		Mock<CoinJoinCoinSelectorRandomnessGenerator> mockGenerator = new(MockBehavior.Loose, CoinJoinCoinSelector.MaxInputsRegistrableByWallet, rng) { CallBase = true };
-		mockGenerator.Setup(c => c.GetInputTarget())
-			.Returns(inputTarget);
+		GetInputTargetSelector fixedInputTarget = () => inputTarget;
+		GetSameTxAllowanceSelector? fixedSameTxAllowance = sameTxAllowance is not null
+				? (percent) => sameTxAllowance.Value
+				: null;
 
-		if (sameTxAllowance is not null)
-		{
-			mockGenerator.Setup(c => c.GetRandomBiasedSameTxAllowance(It.IsAny<int>()))
-				.Returns(sameTxAllowance.Value);
-		}
+		var generator = new CoinJoinCoinSelectorRandomnessGenerator(
+			CoinJoinCoinSelector.MaxInputsRegistrableByWallet,
+			InsecureRandom.Instance,
+			fixedInputTarget,
+			fixedSameTxAllowance);
 
-		return mockGenerator.Object;
+		return generator;
 	}
 
 	private static RoundParameters CreateMultipartyTransactionParameters()

--- a/WalletWasabi/WabiSabi/Client/CoinJoin/Client/CoinJoinCoinSelectorRandomnessGenerator.cs
+++ b/WalletWasabi/WabiSabi/Client/CoinJoin/Client/CoinJoinCoinSelectorRandomnessGenerator.cs
@@ -4,14 +4,28 @@ using WabiSabi.Crypto.Randomness;
 
 namespace WalletWasabi.WabiSabi.Client.CoinJoin.Client;
 
+public delegate int GetInputTargetSelector();
+public delegate int GetSameTxAllowanceSelector(int percent);
+
 /// <summary>
 /// Generator of randomness for <see cref="CoinJoinCoinSelector"/>.
 /// </summary>
 public class CoinJoinCoinSelectorRandomnessGenerator
 {
-	public CoinJoinCoinSelectorRandomnessGenerator(int maxInputsCount, WasabiRandom rnd)
+	private readonly GetInputTargetSelector _inputTargetSelector;
+	private readonly GetSameTxAllowanceSelector _sameTxAllowanceSelector;
+
+	/// <param name="fixedInputTarget">Only for testing purposes.</param>
+	/// <param name="fixedSameTxAllowance">Only for testing purposes.</param>
+	public CoinJoinCoinSelectorRandomnessGenerator(
+		int maxInputsCount,
+		WasabiRandom rnd,
+		GetInputTargetSelector? fixedInputTarget = null,
+		GetSameTxAllowanceSelector? fixedSameTxAllowance = null)
 	{
 		Rnd = rnd;
+		_inputTargetSelector = fixedInputTarget ?? DefaultGetInputTarget;
+		_sameTxAllowanceSelector = fixedSameTxAllowance ?? DefaultGetRandomBiasedSameTxAllowance;
 		_maxInputsCount = maxInputsCount;
 
 		// Until our UTXO count target isn't reached, let's register as few coins as we can to reach it.
@@ -25,25 +39,16 @@ public class CoinJoinCoinSelectorRandomnessGenerator
 	private readonly int _maxInputsCount;
 	private Dictionary<int, int> Distance { get; } = new();
 
-	public virtual int GetRandomBiasedSameTxAllowance(int percent)
-	{
-		for (int num = 0; num <= 100; num++)
-		{
-			if (Rnd.GetInt(1, 101) <= percent)
-			{
-				return num;
-			}
-		}
+	public int GetInputTarget() => _inputTargetSelector();
 
-		return 0;
-	}
+	public int GetRandomBiasedSameTxAllowance(int percent) => _sameTxAllowanceSelector(percent);
 
 	/// <summary>
 	/// Calculates how many inputs are desirable to be registered.
 	/// Note: Random biasing is applied.
 	/// </summary>
 	/// <returns>A number: 1, 2, .., <see cref="CoinJoinCoinSelector.MaxInputsRegistrableByWallet"/>.</returns>
-	public virtual int GetInputTarget()
+	private int DefaultGetInputTarget()
 	{
 		foreach (var best in Distance.OrderBy(x => x.Value))
 		{
@@ -54,5 +59,18 @@ public class CoinJoinCoinSelectorRandomnessGenerator
 		}
 
 		return _maxInputsCount;
+	}
+
+	private int DefaultGetRandomBiasedSameTxAllowance(int percent)
+	{
+		for (int num = 0; num <= 100; num++)
+		{
+			if (Rnd.GetInt(1, 101) <= percent)
+			{
+				return num;
+			}
+		}
+
+		return 0;
 	}
 }


### PR DESCRIPTION
Remove use of `Mock` from `CoinJoinCoinSelectionTests`