### PR TITLE
`upgrade-*.sh` scripts without redownloading

### DIFF
--- a/Contrib/BundledApps/upgrade-bitcoin.sh
+++ b/Contrib/BundledApps/upgrade-bitcoin.sh
@@ -23,18 +23,18 @@ Usage:
     ./upgrade-bitcoin-core.sh <version> [OPTIONS]
 
 Arguments:
-    <version>          Bitcoin Core version (required)  e.g. 30.2 or 29.3
+    <version>          Bitcoin Core version (required)  e.g. 30.2
 
 Options:
     -h, --help         Show this help message and exit
-    --skip-download    Skip downloading the release archives (use previously downloaded files)
+    --force-download   Force download even if files already exist
     --skip-extract     Skip extracting the archives
     --skip-replace     Skip replacing the binaries in the target directory/repository
 
 Examples:
     ./upgrade-bitcoin-core.sh 30.2
-    ./upgrade-bitcoin-core.sh 30.2 --skip-download
-    ./upgrade-bitcoin-core.sh 29.3 --skip-download --skip-extract
+    ./upgrade-bitcoin-core.sh 30.2 --force-download
+    ./upgrade-bitcoin-core.sh 30.2 --skip-extract
 
 See also:
     https://bitcoincore.org/en/download
@@ -54,18 +54,18 @@ VERSION="${1:-}"
 if [[ -z "$VERSION" ]]; then
     echo "ERROR: Bitcoin Core version is required." >&2
     echo "Use -h or --help for usage information." >&2
-    echo "Usage: $0 <version> [--skip-download] [--skip-extract] [--skip-replace]" >&2
+    echo "Usage: $0 <version> [--force-download] [--skip-extract] [--skip-replace]" >&2
     exit 1
 fi
 
 # Parse flags
-SKIP_DOWNLOAD=false
+FORCE_DOWNLOAD=false
 SKIP_EXTRACT=false
 SKIP_REPLACE=false
 
 for arg in "$@"; do
     case "$arg" in
-        --skip-download)  SKIP_DOWNLOAD=true ;;
+        --force-download) FORCE_DOWNLOAD=true ;;
         --skip-extract)   SKIP_EXTRACT=true ;;
         --skip-replace)   SKIP_REPLACE=true ;;
     esac
@@ -113,6 +113,40 @@ require_command() {
 }
 
 # ──────────────────────────────────────────────────────────────────────────────
+#  Functions
+# ──────────────────────────────────────────────────────────────────────────────
+
+download_checksums_file_and_pgp() {
+    info "Downloading and verifying SHA256SUMS and signatures..."
+
+    # Download checksum files
+    curl -fL -o SHA256SUMS "${DIST_URI}/SHA256SUMS" || error "Failed to download SHA256SUMS"
+    curl -fL -o SHA256SUMS.asc "${DIST_URI}/SHA256SUMS.asc" || error "Failed to download SHA256SUMS.asc"
+
+    # Import signing keys (Ava Chow + fanquake)
+    curl -fL -o achow101.gpg https://keys.openpgp.org/vks/v1/by-fingerprint/152812300785C96444D3334D17565732E08E5E41 || error "Failed to download achow101's key"
+    curl -fL -o fanquake.gpg https://keys.openpgp.org/vks/v1/by-fingerprint/E777299FC265DD04793070EB944D35F9AC3DB76A || error "Failed to download fanquake's key"
+
+    gpg --import achow101.gpg 2>/dev/null || true
+    gpg --import fanquake.gpg 2>/dev/null || true
+}
+
+verify_checksums() {
+    gpg --verify SHA256SUMS.asc SHA256SUMS >gpg_result.log 2>&1 || true
+
+    if grep --fixed-strings -q "gpg: Good signature" gpg_result.log; then
+        info "GPG verification PASSED: at least one good signature found on SHA256SUMS"
+    else
+        error "GPG verification FAILED.\n\nOutput from gpg: $(gpg --verify SHA256SUMS.asc SHA256SUMS 2>&1)"
+    fi
+
+    if sha256sum -c --ignore-missing SHA256SUMS | grep -v "OK$"; then
+        error "Checksum verification FAILED — see output above"
+    fi
+    info "All checksums OK"
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
 #  Checks
 # ──────────────────────────────────────────────────────────────────────────────
 
@@ -151,47 +185,32 @@ pushd "$TEMP_DIR" >/dev/null || exit 1
 info "Change directory to $TEMP_DIR"
 
 # ─── Download ────────────────────────────────────────────────────────────────
-if [[ "$SKIP_DOWNLOAD" != true ]]; then
-    section "Downloading Bitcoin Core packages"
+section "Downloading Bitcoin Core packages"
 
-    rm -rf BitcoinCore
+downloadChecksumsFile=true
 
-    # Download checksums first
-    info "Downloading SHA256SUMS and its signature..."
-    echo "${DIST_URI}/SHA256SUMS"
-    curl -fL -o SHA256SUMS "${DIST_URI}/SHA256SUMS" || error "Failed to download SHA256SUMS"
-    curl -fL -o SHA256SUMS.asc "${DIST_URI}/SHA256SUMS.asc" || error "Failed to download SHA256SUMS.asc"
+# Download platform binaries only if missing or forced
+for platform in "${SUPPORTED_PLATFORMS[@]}"; do
+    fname="${FILES[$platform]}"
+    url="${DIST_URI}/${fname}"
 
-    # Ava Chow + Michael Ford (fanquake)
-    curl -fL -o achow101.gpg https://keys.openpgp.org/vks/v1/by-fingerprint/152812300785C96444D3334D17565732E08E5E41 || error "Failed to download achow101's gpg"
-    curl -fL -o fanquake.gpg https://keys.openpgp.org/vks/v1/by-fingerprint/E777299FC265DD04793070EB944D35F9AC3DB76A || error "Failed to download fanquake's gpg"
-    gpg --import achow101.gpg || true
-    gpg --import fanquake.gpg || true
-
-    gpg --verify SHA256SUMS.asc SHA256SUMS >gpg_result.log 2>&1 || true
-
-    if grep --fixed-strings -q "gpg: Good signature" gpg_result.log; then
-        info "GPG verification PASSED: at least one good signature found on SHA256SUMS"
-    else
-        error "GPG verification FAILED.\n\nOutput from gpg: $(gpg --verify SHA256SUMS.asc SHA256SUMS 2>&1)"
-    fi
-
-    for platform in "${SUPPORTED_PLATFORMS[@]}"; do
-        fname="${FILES[$platform]}"
-        url="${DIST_URI}/${fname}"
-
+    if [[ "$FORCE_DOWNLOAD" == true ]] || [[ ! -f "$fname" ]]; then
         info "Downloading $fname from '$url' ..."
+
+        # Call the function only when we are actually downloading a file
+        if [[ "$downloadChecksumsFile" == true ]]; then
+            download_checksums_file_and_pgp
+            downloadChecksumsFile=false
+        fi
+
         curl -fL --progress-bar -o "$fname" "$url" || error "Download of '$fname' failed: $url"
-    done
-
-    if sha256sum -c --ignore-missing SHA256SUMS | grep -v "OK$"; then
-        error "Checksum verification FAILED — see output above"
+    else
+        info "File already exists: $fname (skipping download)"
     fi
+done
 
-    info "All checksums OK"
-else
-    section "Skipping download"
-fi
+# Verify all checksums (whether we downloaded some files or not)
+verify_checksums
 
 # ─── Extract Bitcoin Core archives ────────────────────────────────────────────────
 if [[ "$SKIP_EXTRACT" != true ]]; then

--- a/Contrib/BundledApps/upgrade-hwi.sh
+++ b/Contrib/BundledApps/upgrade-hwi.sh
@@ -27,14 +27,15 @@ Arguments:
 
 Options:
     -h, --help         Show this help message and exit
-    --skip-download    Skip downloading the release archives (use files from previous run)
+    --force-download   Force download even if files already exist
     --skip-extract     Skip extracting the downloaded archives
     --skip-replace     Skip replacing the HWI binaries in the repository
 
 Examples:
     ./upgrade-hwi.sh 3.2.0
-    ./upgrade-hwi.sh 3.1.0 --skip-download
-    ./upgrade-hwi.sh 3.2.0 --skip-download --skip-extract
+    ./upgrade-hwi.sh 3.2.0 --force-download
+    ./upgrade-hwi.sh 3.2.0 --skip-extract
+    ./upgrade-hwi.sh 3.2.0 --force-download --skip-extract
 
 See also:
     https://github.com/bitcoin-core/HWI/
@@ -54,20 +55,20 @@ VERSION="${1:-}"
 if [[ -z "$VERSION" ]]; then
     echo "ERROR: HWI version is required." >&2
     echo "Use -h or --help for usage information." >&2
-    echo "Usage: $0 <version> [--skip-download] [--skip-extract] [--skip-replace]" >&2
+    echo "Usage: $0 <version> [--force-download] [--skip-extract] [--skip-replace]" >&2
     exit 1
 fi
 
 # Parse flags
-SKIP_DOWNLOAD=false
+FORCE_DOWNLOAD=false
 SKIP_EXTRACT=false
 SKIP_REPLACE=false
 
 for arg in "$@"; do
     case "$arg" in
-        --skip-download) SKIP_DOWNLOAD=true ;;
-        --skip-extract)  SKIP_EXTRACT=true ;;
-        --skip-replace)  SKIP_REPLACE=true ;;
+        --force-download) FORCE_DOWNLOAD=true ;;
+        --skip-extract)   SKIP_EXTRACT=true ;;
+        --skip-replace)   SKIP_REPLACE=true ;;
     esac
 done
 
@@ -82,6 +83,8 @@ FILES[linux-arm64]="hwi-${VERSION}-linux-aarch64.tar.gz"
 FILES[linux-x64]="hwi-${VERSION}-linux-x86_64.tar.gz"
 FILES[osx64]="hwi-${VERSION}-mac-x86_64.tar.gz"
 FILES[win-x64]="hwi-${VERSION}-windows-x86_64.zip"
+
+CHECKSUM_FILE="SHA256SUMS.txt.asc"
 
 SUPPORTED_PLATFORMS=("linux-arm64" "linux-x64" "osx64" "win-x64")
 
@@ -110,6 +113,37 @@ section() {
 
 require_command() {
     command -v "$1" >/dev/null 2>&1 || error "Required command not found: $1"
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+#  Functions
+# ──────────────────────────────────────────────────────────────────────────────
+
+download_checksums_file_and_pgp() {
+    # Download checksum file and import key only if needed
+    info "Downloading checksum file and signing key..."
+
+    # Download SHA256SUMS.txt.asc
+    local url="${DIST_URI}/$CHECKSUM_FILE"
+    info "Downloading $CHECKSUM_FILE from '$url' ..."
+    curl -fL --progress-bar -o "$CHECKSUM_FILE" "$url" || error "Download of '$CHECKSUM_FILE' failed"
+
+    # Download achow101.pgp
+    # See https://achow101.com/contact/
+    url="http://achow101.com/achow101.pgp"
+    info "Downloading 'achow101.pgp' from '$url' ..."
+    curl -fsSL --output achow101.pgp "${url}"
+    gpg --import ./achow101.pgp
+    gpg --list-keys --fingerprint 17565732E08E5E41
+    gpg --verify "${CHECKSUM_FILE}"
+    info "Signature OK for $CHECKSUM_FILE"
+}
+
+verify_checksums() {
+    # Verify the checksum signature
+    gpg --verify "${CHECKSUM_FILE}" 2>&1 | grep -q "Good signature" || error "GPG verification of $CHECKSUM_FILE failed"
+
+    info "Signature verification passed for $CHECKSUM_FILE"
 }
 
 # ──────────────────────────────────────────────────────────────────────────────
@@ -149,44 +183,39 @@ pushd "$TEMP_DIR" >/dev/null || exit 1
 info "Change directory to $TEMP_DIR"
 
 # ─── Download ────────────────────────────────────────────────────────────────
-if [[ "$SKIP_DOWNLOAD" != true ]]; then
-    section "Downloading HWI packages"
+section "Downloading HWI packages"
 
-    CHECKSUM_FILE="SHA256SUMS.txt.asc"
+downloadChecksumsFile=true
 
-    url="${DIST_URI}/$CHECKSUM_FILE"
-    info "Downloading $CHECKSUM_FILE from '$url' ..."
-    curl -fL --progress-bar -o "$CHECKSUM_FILE" "$url" || error "Download of '$CHECKSUM_FILE' failed: $url"
+# Download platform binaries only if missing or forced
+for platform in "${SUPPORTED_PLATFORMS[@]}"; do
+    fname="${FILES[$platform]}"
+    url="${DIST_URI}/${fname}"
 
-    # See https://achow101.com/contact/
-    url="http://achow101.com/achow101.pgp"
-    info "Downloading 'achow101.pgp' from '$url' ..."
-    curl -fsSL --output achow101.pgp "${url}"
-    gpg --import ./achow101.pgp
-    gpg --list-keys --fingerprint 17565732E08E5E41
-    gpg --verify "${CHECKSUM_FILE}"
-    info "Signature OK for $CHECKSUM_FILE"
+    if [[ "$FORCE_DOWNLOAD" == true ]] || [[ ! -f "$fname" ]]; then
+        info "Downloading $fname ..."
 
-    for platform in "${SUPPORTED_PLATFORMS[@]}"; do
-        fname="${FILES[$platform]}"
-        url="${DIST_URI}/${fname}"
-
-        info "Downloading $fname from '$url' ..."
-        curl -fL --progress-bar -o "$fname" "$url" || error "Download of '$fname' failed: $url"
-
-        # Verify downloaded .gz/.zip file's SHA256 hash against hashes in SHA256SUMS.txt.asc.
-        actual_line=$(sha256sum --text $fname)
-        found=$(grep --fixed-strings --line-regexp --quiet "$actual_line" "$CHECKSUM_FILE" && echo true || echo false)
-        if ! $found; then
-            error "Line '$actual_line' not present in $CHECKSUM_FILE"
-            exit 1
+        # Call the function only when we are actually downloading a file
+        if [[ "$downloadChecksumsFile" == true ]]; then
+            download_checksums_file_and_pgp
+            downloadChecksumsFile=false
         fi
-        
-        info "SHA256 hash is OK for $fname"
-    done
-else
-    section "Skipping download"
-fi
+
+        curl -fL --progress-bar -o "$fname" "$url" || error "Download of '$fname' failed"
+    else
+        info "File already exists: $fname (skipping download)"
+    fi
+
+    # Verify SHA256 hash against the checksum file
+    actual_line=$(sha256sum --text "$fname")
+    if ! grep -qF "$actual_line" "$CHECKSUM_FILE"; then
+        error "SHA256 hash verification FAILED for $fname"
+    fi
+
+    info "SHA256 hash is OK for $fname"
+done
+
+verify_checksums
 
 # ─── Extract only HWI archives ────────────────────────────────────────────────
 if [[ "$SKIP_EXTRACT" != true ]]; then

--- a/Contrib/BundledApps/upgrade-tor.sh
+++ b/Contrib/BundledApps/upgrade-tor.sh
@@ -27,7 +27,7 @@ Arguments:
 
 Options:
     -h, --help              Show this help message and exit
-    --skip-download         Skip downloading archives (use previously downloaded files)
+    --force-download        Force download Tor Browser archives even if they already exist
     --skip-extract-browser  Skip extracting the Tor Browser archive
     --skip-extract-tor      Skip extracting the embedded Tor from browser
     --skip-replace-tor      Skip replacing the Tor binaries in the repository
@@ -35,8 +35,8 @@ Options:
 
 Examples:
     ./upgrade-tor.sh 15.0.7
-    ./upgrade-tor.sh 15.0.7 --skip-download
-    ./upgrade-tor.sh 15.0.7 --skip-download --skip-extract-browser --skip-replace-geoip
+    ./upgrade-tor.sh 15.0.7 --force-download
+    ./upgrade-tor.sh 15.0.7 --skip-extract-browser --skip-replace-geoip
 EOF
     exit 0
 }
@@ -52,12 +52,12 @@ VERSION="${1:-}"
 if [[ -z "$VERSION" ]]; then
     echo "ERROR: Tor Browser version is required." >&2
     echo "Use --help for usage information." >&2
-    echo "Usage: $0 <version> [--skip-download] [--skip-extract-browser] [--skip-extract-tor] [--skip-replace-tor] [--skip-replace-geoip]" >&2
+    echo "Usage: $0 <version> [--force-download] [--skip-extract-browser] [--skip-extract-tor] [--skip-replace-tor] [--skip-replace-geoip]" >&2
     exit 1
 fi
 
 # Parse flags
-SKIP_DOWNLOAD=false
+FORCE_DOWNLOAD=false
 SKIP_EXTRACT_BROWSER=false
 SKIP_EXTRACT_TOR=false
 SKIP_REPLACE_TOR=false
@@ -65,7 +65,7 @@ SKIP_REPLACE_GEOIP=false
 
 for arg in "$@"; do
     case "$arg" in
-        --skip-download)        SKIP_DOWNLOAD=true ;;
+        --force-download)       FORCE_DOWNLOAD=true ;;
         --skip-extract-browser) SKIP_EXTRACT_BROWSER=true ;;
         --skip-extract-tor)     SKIP_EXTRACT_TOR=true ;;
         --skip-replace-tor)     SKIP_REPLACE_TOR=true ;;
@@ -153,43 +153,51 @@ pushd "$TEMP_DIR" >/dev/null || exit 1
 info "Change directory to $TEMP_DIR"
 
 # ─── Download ────────────────────────────────────────────────────────────────
-if [[ "$SKIP_DOWNLOAD" != true ]]; then
-    section "Downloading Tor Browser packages"
+section "Downloading Tor Browser packages (if needed)"
 
-    rm -rf TorBrowser Tor
-
-    # https://support.torproject.org/tor-browser/getting-started/verifying-tor-browser/
+if [[ "$FORCE_DOWNLOAD" == true ]] || [[ ! -f "./tor.keyring" ]]; then
     info "Fetching the Tor Developers key"
-    rm -rf ./tor.keyring
-    gpg --auto-key-locate nodefault,wkd --locate-keys torbrowser@torproject.org
-    gpg --output ./tor.keyring --export 0xEF6E286DDA85EA2A4BA7DE684E2C6E8793298290
+    
+    # https://support.torproject.org/tor-browser/getting-started/verifying-tor-browser/
+    gpg --auto-key-locate nodefault,wkd --locate-keys torbrowser@torproject.org    # Import key from Web Key Directory (WKD)
+    gpg --output ./tor.keyring --export 0xEF6E286DDA85EA2A4BA7DE684E2C6E8793298290 # Export the specific key to a local keyring file
 
-    for platform in "${SUPPORTED_PLATFORMS[@]}"; do
-        fname="${FILES[$platform]}"
-        url="${DIST_URI}/${fname}"
+    info "Tor Developers keyring created/updated"
+else
+    info "Tor keyring already exists. Skipping fetch."
+fi
 
+for platform in "${SUPPORTED_PLATFORMS[@]}"; do
+    fname="${FILES[$platform]}"
+    url="${DIST_URI}/${fname}"
+
+    asc_fname="${fname}.asc"
+    asc_url="${url}.asc"
+
+    # Download only if file doesn't exist, unless --force-download is used.
+    if [[ "$FORCE_DOWNLOAD" == true ]] || [[ ! -f "$fname" ]] || [[ ! -f "$asc_fname" ]]; then
         info "Downloading $fname from '$url' ..."
         curl -fL --progress-bar -o "$fname" "$url" || error "Download of '$fname' failed: $url"
 
-        url="${url}.asc"
-        asc_fname="${FILES[$platform]}.asc"
+        info "Downloading $asc_fname from '$asc_url' ..."
+        curl -fL --progress-bar -o "$asc_fname" "$asc_url" || error "Download of '$asc_fname' failed: $asc_url"
+    else
+        info "File already exists: $fname (skipping download)"
+    fi
 
-        info "Downloading $asc_fname from '$url' ..."
-        curl -fL --progress-bar -o "$asc_fname" "$url" || error "Download of '$asc_fname' failed: $url"
-
-        if gpgv --keyring ./tor.keyring "$asc_fname" "$fname" >gpg-verify.log 2>&1; then
-            info "Signature OK for $fname"
-        else
-            gpgLog=$(cat ./gpg-verify.log)
-            error "Verification FAILED for $fname" "$gpgLog"
-        fi
-    done
-else
-    section "Skipping download"
-fi
+    # Verify signature
+    if gpgv --keyring ./tor.keyring "$asc_fname" "$fname" >gpg-verify.log 2>&1; then
+        info "Signature OK for $fname"
+    else
+        gpgLog=$(cat ./gpg-verify.log)
+        error "Verification FAILED for $fname" "$gpgLog"
+    fi
+done
 
 # ─── Extract browser archives ────────────────────────────────────────────────
 if [[ "$SKIP_EXTRACT_BROWSER" != true ]]; then
+    rm -rf TorBrowser Tor
+
     section "Extracting Tor Browser archives"
 
     # Remove WalletWasabi/BundledApps/Binaries/temp/$VERSION/TorBrowser


### PR DESCRIPTION
This is a part of #14458

When an `upgrade-*.sh` script is called, it should, by default, not re-download data from the Internet if the data is present locally. 

The reason why it is important is that switching between git branches should be reasonably user-friendly. Doing

```
git checkout feature-branch
./restore.sh
```

and waiting for downloading tens or hundreds of megabytes of data would be bad[^1]. Therefore, this PR checks if the needed file is locally stored (in `temp` folder in the WW repo) and if it is, it just uses it. 

## Test

Clear `WalletWasabi/BundledApps/Binaries/temp` and `WalletWasabi.Tests\BundledApps\Binaries\temp` folders.

```
./Contrib/BundledApps/upgrade-hwi.sh 3.2.0 # should download files over the Internet
./Contrib/BundledApps/upgrade-hwi.sh 3.2.0 # should not download files over the Internet (cached from the previous run)
./Contrib/BundledApps/upgrade-hwi.sh 3.2.0 --force-download # should download files
```

similarly for `upgrade-bitcoin.sh` and `upgrade-tor.sh`.

Example of ` Contrib/BundledApps/upgrade-tor.sh 16.0a5` when files are present:

```
# Downloading Tor Browser packages (if needed)

[INFO]  Tor keyring already exists. Skipping fetch.
[INFO]  File already exists: tor-browser-linux-aarch64-16.0a5.tar.xz (skipping download)
[INFO]  Signature OK for tor-browser-linux-aarch64-16.0a5.tar.xz
[INFO]  File already exists: tor-browser-linux-x86_64-16.0a5.tar.xz (skipping download)
[INFO]  Signature OK for tor-browser-linux-x86_64-16.0a5.tar.xz
[INFO]  File already exists: tor-browser-macos-16.0a5.dmg (skipping download)
[INFO]  Signature OK for tor-browser-macos-16.0a5.dmg
[INFO]  File already exists: tor-browser-windows-x86_64-portable-16.0a5.exe (skipping download)
[INFO]  Signature OK for tor-browser-windows-x86_64-portable-16.0a5.exe
```

[^1]: It should be reasonably uncommon to happen though because HWI, Tor and Bitcoin full node are backward compatible a lot.