### PR TITLE
Primitives: Add `Encode.ObjectWithOptionalProperties` 

### DIFF
--- a/WalletWasabi/Blockchain/Keys/KeyManager.cs
+++ b/WalletWasabi/Blockchain/Keys/KeyManager.cs
@@ -758,10 +758,10 @@ public class KeyManager
 	}
 
 	private static JsonNode EncodeKeyManager(KeyManager keyManager) =>
-		Encode.Object([
-			("EncryptedSecret", Encode.Optional(keyManager.EncryptedSecret, Encode.BitcoinEncryptedSecretNoEC)),
-			("ChainCode", Encode.Optional(keyManager.ChainCode, Encode.ChainCode)),
-			("MasterFingerprint", Encode.Optional(keyManager.MasterFingerprint, Encode.HDFingerprint)),
+		Encode.ObjectWithOptionalProperties([
+			Encode.OptionalProperty("EncryptedSecret", keyManager.EncryptedSecret, Encode.BitcoinEncryptedSecretNoEC),
+			Encode.OptionalProperty("ChainCode", keyManager.ChainCode, Encode.ChainCode),
+			Encode.OptionalProperty("MasterFingerprint", keyManager.MasterFingerprint, Encode.HDFingerprint),
 			("ExtPubKey", Encode.ExtPubKey(keyManager.SegwitExtPubKey)),
 			("TaprootExtPubKey", Encode.Optional(keyManager.TaprootExtPubKey, Encode.ExtPubKey)),
 			("SilentPaymentScanExtPubKey", Encode.Optional(keyManager.SilentPaymentScanExtPubKey, Encode.ExtPubKey)),

--- a/WalletWasabi/Serialization/Client.cs
+++ b/WalletWasabi/Serialization/Client.cs
@@ -19,8 +19,8 @@ public static partial class Encode
 	public static JsonNode ByteArray(byte[] bytes) =>
 		String(Convert.ToBase64String(bytes));
 
-	public static JsonNode? ChainCode(byte[]? bytes) =>
-		Optional(bytes, ByteArray);
+	public static JsonNode ChainCode(byte[] bytes) =>
+		ByteArray(bytes);
 
 	public static JsonNode PubKey(PubKey pk) =>
 		String(pk.ToHex());
@@ -51,11 +51,18 @@ public static partial class Encode
 			("TweakData", ECPubKey(hd.TweakData!))
 		]);
 
-	public static JsonNode? HDFingerprint(HDFingerprint? fp) =>
-		Optional(fp?.ToString(), String);
+	public static JsonNode HDFingerprint(HDFingerprint? fp)
+	{
+		if (fp is null)
+		{
+			throw new ArgumentNullException(nameof(fp));
+		}
 
-	public static JsonNode? BitcoinEncryptedSecretNoEC(BitcoinEncryptedSecretNoEC? s) =>
-		Optional(s?.ToWif(), String);
+		return String(fp.Value.ToString());
+	}
+
+	public static JsonNode BitcoinEncryptedSecretNoEC(BitcoinEncryptedSecretNoEC s) =>
+		String(s.ToWif());
 
 	public static JsonNode WalletHeight(ChainHeight height) =>
 		String(Math.Max(0, height.Height - Constants.ResyncHeightMargin).ToString());

--- a/WalletWasabi/Serialization/Primitives.cs
+++ b/WalletWasabi/Serialization/Primitives.cs
@@ -41,6 +41,10 @@ public static partial class Encode
 	public static JsonNode Object(IEnumerable<(string, JsonNode?)> values) => new JsonObject(values.ToDictionary(x => x.Item1, x => x.Item2));
 
 	[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public static JsonNode ObjectWithOptionalProperties(IEnumerable<(string, JsonNode?)?> values) =>
+		Object(values.Where(x => x is not null).Cast<(string, JsonNode?)>());
+
+	[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public static JsonNode Array(IEnumerable<JsonNode> values) => new JsonArray(values.ToArray());
 
 	[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -58,6 +62,10 @@ public static partial class Encode
 	[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
 	public static JsonNode? Optional<T>(T? value, Encoder<T> encoder) =>
 		value is { } nonNullValue ? encoder(nonNullValue) : null;
+
+	[Pure, MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public static (string, JsonNode?)? OptionalProperty<T>(string propertyName, T? value, Encoder<T> encoder) =>
+		value is null ? null : (propertyName, encoder(value));
 }
 
 
@@ -117,7 +125,7 @@ public static partial class Decode
 	public static Decoder<double> Double =>
 		Decimal.Map(d => (double) d);
 
-	public static Decoder<DateTimeOffset> DateTimeOffset =
+	public static readonly Decoder<DateTimeOffset> DateTimeOffset =
 		String.Map(System.DateTimeOffset.Parse);
 
 	public static Decoder<T> Succeed<T>(T output) =>
@@ -131,18 +139,6 @@ public static partial class Decode
 		{
 			var m = decoder(value);
 			return m.IsOk ? f(m.Value) : m.Error;
-		};
-
-	public static Decoder<T> Map2<T, R, U>(Func<R, U, T> ctor, Decoder<R> d1, Decoder<U> d2) =>
-		value =>
-		{
-			var (m1, m2) = (d1(value), d2(value));
-			return (m1.IsOk, m2.IsOk) switch
-			{
-				(true, true) => ctor(m1.Value, m2.Value),
-				(false, _) => Result<T, string>.Fail(m1.Error),
-				(_, false) => Result<T, string>.Fail(m2.Error),
-			};
 		};
 
 	public static Decoder<T> Index<T>(int index, Decoder<T> decoder) =>


### PR DESCRIPTION
12 warnings -> 9 warnings

This PR fixes several nullability warnings here: https://github.com/WalletWasabi/WalletWasabi/blob/6c5974e18fe6d9afd43bd3fab3bb405f8a52f55a/WalletWasabi/Blockchain/Keys/KeyManager.cs#L766-L790