### PR TITLE
Nbitcoin: Upgrade to 10.0.3

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -29,7 +29,7 @@
     <PackageVersion Include="System.Linq.Async" Version="7.0.0" />
     <!-- Core libraries. -->
     <PackageVersion Include="WabiSabi" Version="1.0.1.2" />
-    <PackageVersion Include="NBitcoin" Version="9.0.5" />
+    <PackageVersion Include="NBitcoin" Version="10.0.3" />
     <!-- UI. -->
     <PackageVersion Include="Avalonia" Version="$(AvaloniaVersion)" />
     <PackageVersion Include="Avalonia.Controls.TreeDataGrid" Version="11.1.1" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -29,7 +29,7 @@
     <PackageVersion Include="System.Linq.Async" Version="7.0.0" />
     <!-- Core libraries. -->
     <PackageVersion Include="WabiSabi" Version="1.0.1.2" />
-    <PackageVersion Include="NBitcoin" Version="8.0.14" />
+    <PackageVersion Include="NBitcoin" Version="9.0.5" />
     <!-- UI. -->
     <PackageVersion Include="Avalonia" Version="$(AvaloniaVersion)" />
     <PackageVersion Include="Avalonia.Controls.TreeDataGrid" Version="11.1.1" />

--- a/WalletWasabi.Client/packages.lock.json
+++ b/WalletWasabi.Client/packages.lock.json
@@ -208,7 +208,7 @@
           "Microsoft.Extensions.Hosting.Abstractions": "[10.0.2, )",
           "Microsoft.Extensions.Http": "[10.0.2, )",
           "Microsoft.Win32.SystemEvents": "[10.0.2, )",
-          "NBitcoin": "[9.0.5, )",
+          "NBitcoin": "[10.0.3, )",
           "NNostr.Client": "[0.0.54, )",
           "System.Linq.Async": "[7.0.0, )",
           "WabiSabi": "[1.0.1.2, )"
@@ -278,9 +278,9 @@
       },
       "NBitcoin": {
         "type": "CentralTransitive",
-        "requested": "[9.0.5, )",
-        "resolved": "9.0.5",
-        "contentHash": "twjb1YfGcOW2UaR+GWMDGMPKQgjwVyzARML4oGxSSZQO8CyzULel2ipOUC6nhCpP6XN1fVGNQmOWfbD5AI8ksw==",
+        "requested": "[10.0.3, )",
+        "resolved": "10.0.3",
+        "contentHash": "nuzZn+IziBmZXySg+G48UT2g2YZ7SgjsK9qdIefkRjsbw2ddeQEXuoHFtvB0w2A6YlQgjio09g5Y5PnMHMfZwA==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "1.0.0",
           "Newtonsoft.Json": "13.0.1"

--- a/WalletWasabi.Client/packages.lock.json
+++ b/WalletWasabi.Client/packages.lock.json
@@ -208,7 +208,7 @@
           "Microsoft.Extensions.Hosting.Abstractions": "[10.0.2, )",
           "Microsoft.Extensions.Http": "[10.0.2, )",
           "Microsoft.Win32.SystemEvents": "[10.0.2, )",
-          "NBitcoin": "[8.0.14, )",
+          "NBitcoin": "[9.0.5, )",
           "NNostr.Client": "[0.0.54, )",
           "System.Linq.Async": "[7.0.0, )",
           "WabiSabi": "[1.0.1.2, )"
@@ -278,9 +278,9 @@
       },
       "NBitcoin": {
         "type": "CentralTransitive",
-        "requested": "[8.0.14, )",
-        "resolved": "8.0.14",
-        "contentHash": "pRrgEC7HNvOvjGeqHWIOjz/S3OcQiJ7nLRDokreXU5VShfjXWkiOjt9aP/zswliPheRfcAQWFU/BjlMIgwBlLg==",
+        "requested": "[9.0.5, )",
+        "resolved": "9.0.5",
+        "contentHash": "twjb1YfGcOW2UaR+GWMDGMPKQgjwVyzARML4oGxSSZQO8CyzULel2ipOUC6nhCpP6XN1fVGNQmOWfbD5AI8ksw==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "1.0.0",
           "Newtonsoft.Json": "13.0.1"

--- a/WalletWasabi.Daemon/packages.lock.json
+++ b/WalletWasabi.Daemon/packages.lock.json
@@ -195,7 +195,7 @@
           "Microsoft.Extensions.Hosting.Abstractions": "[10.0.2, )",
           "Microsoft.Extensions.Http": "[10.0.2, )",
           "Microsoft.Win32.SystemEvents": "[10.0.2, )",
-          "NBitcoin": "[8.0.14, )",
+          "NBitcoin": "[9.0.5, )",
           "NNostr.Client": "[0.0.54, )",
           "System.Linq.Async": "[7.0.0, )",
           "WabiSabi": "[1.0.1.2, )"
@@ -285,9 +285,9 @@
       },
       "NBitcoin": {
         "type": "CentralTransitive",
-        "requested": "[8.0.14, )",
-        "resolved": "8.0.14",
-        "contentHash": "pRrgEC7HNvOvjGeqHWIOjz/S3OcQiJ7nLRDokreXU5VShfjXWkiOjt9aP/zswliPheRfcAQWFU/BjlMIgwBlLg==",
+        "requested": "[9.0.5, )",
+        "resolved": "9.0.5",
+        "contentHash": "twjb1YfGcOW2UaR+GWMDGMPKQgjwVyzARML4oGxSSZQO8CyzULel2ipOUC6nhCpP6XN1fVGNQmOWfbD5AI8ksw==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "1.0.0",
           "Newtonsoft.Json": "13.0.1"

--- a/WalletWasabi.Daemon/packages.lock.json
+++ b/WalletWasabi.Daemon/packages.lock.json
@@ -195,7 +195,7 @@
           "Microsoft.Extensions.Hosting.Abstractions": "[10.0.2, )",
           "Microsoft.Extensions.Http": "[10.0.2, )",
           "Microsoft.Win32.SystemEvents": "[10.0.2, )",
-          "NBitcoin": "[9.0.5, )",
+          "NBitcoin": "[10.0.3, )",
           "NNostr.Client": "[0.0.54, )",
           "System.Linq.Async": "[7.0.0, )",
           "WabiSabi": "[1.0.1.2, )"
@@ -285,9 +285,9 @@
       },
       "NBitcoin": {
         "type": "CentralTransitive",
-        "requested": "[9.0.5, )",
-        "resolved": "9.0.5",
-        "contentHash": "twjb1YfGcOW2UaR+GWMDGMPKQgjwVyzARML4oGxSSZQO8CyzULel2ipOUC6nhCpP6XN1fVGNQmOWfbD5AI8ksw==",
+        "requested": "[10.0.3, )",
+        "resolved": "10.0.3",
+        "contentHash": "nuzZn+IziBmZXySg+G48UT2g2YZ7SgjsK9qdIefkRjsbw2ddeQEXuoHFtvB0w2A6YlQgjio09g5Y5PnMHMfZwA==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "1.0.0",
           "Newtonsoft.Json": "13.0.1"

--- a/WalletWasabi.Fluent.Desktop/packages.lock.json
+++ b/WalletWasabi.Fluent.Desktop/packages.lock.json
@@ -562,7 +562,7 @@
           "Microsoft.Extensions.Hosting.Abstractions": "[10.0.2, )",
           "Microsoft.Extensions.Http": "[10.0.2, )",
           "Microsoft.Win32.SystemEvents": "[10.0.2, )",
-          "NBitcoin": "[9.0.5, )",
+          "NBitcoin": "[10.0.3, )",
           "NNostr.Client": "[0.0.54, )",
           "System.Linq.Async": "[7.0.0, )",
           "WabiSabi": "[1.0.1.2, )"
@@ -757,9 +757,9 @@
       },
       "NBitcoin": {
         "type": "CentralTransitive",
-        "requested": "[9.0.5, )",
-        "resolved": "9.0.5",
-        "contentHash": "twjb1YfGcOW2UaR+GWMDGMPKQgjwVyzARML4oGxSSZQO8CyzULel2ipOUC6nhCpP6XN1fVGNQmOWfbD5AI8ksw==",
+        "requested": "[10.0.3, )",
+        "resolved": "10.0.3",
+        "contentHash": "nuzZn+IziBmZXySg+G48UT2g2YZ7SgjsK9qdIefkRjsbw2ddeQEXuoHFtvB0w2A6YlQgjio09g5Y5PnMHMfZwA==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "1.0.0",
           "Newtonsoft.Json": "13.0.1"

--- a/WalletWasabi.Fluent.Desktop/packages.lock.json
+++ b/WalletWasabi.Fluent.Desktop/packages.lock.json
@@ -562,7 +562,7 @@
           "Microsoft.Extensions.Hosting.Abstractions": "[10.0.2, )",
           "Microsoft.Extensions.Http": "[10.0.2, )",
           "Microsoft.Win32.SystemEvents": "[10.0.2, )",
-          "NBitcoin": "[8.0.14, )",
+          "NBitcoin": "[9.0.5, )",
           "NNostr.Client": "[0.0.54, )",
           "System.Linq.Async": "[7.0.0, )",
           "WabiSabi": "[1.0.1.2, )"
@@ -757,9 +757,9 @@
       },
       "NBitcoin": {
         "type": "CentralTransitive",
-        "requested": "[8.0.14, )",
-        "resolved": "8.0.14",
-        "contentHash": "pRrgEC7HNvOvjGeqHWIOjz/S3OcQiJ7nLRDokreXU5VShfjXWkiOjt9aP/zswliPheRfcAQWFU/BjlMIgwBlLg==",
+        "requested": "[9.0.5, )",
+        "resolved": "9.0.5",
+        "contentHash": "twjb1YfGcOW2UaR+GWMDGMPKQgjwVyzARML4oGxSSZQO8CyzULel2ipOUC6nhCpP6XN1fVGNQmOWfbD5AI8ksw==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "1.0.0",
           "Newtonsoft.Json": "13.0.1"

--- a/WalletWasabi.Fluent/Models/Wallets/WalletInfoModel.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/WalletInfoModel.cs
@@ -20,7 +20,7 @@ public partial class WalletInfoModel
 			ExtendedMasterZprv = secret.ToZPrv(network);
 
 			// TODO: Should work for every type of wallet, temporarily disabling it.
-			WpkhWalletPolicies = wallet.KeyManager.GetWpkhWalletPolicies(wallet.Password, network);
+			WpkhWalletPolicy = wallet.KeyManager.GetWpkhWalletPolicy(wallet.Password, network);
 		}
 
 		SegWitExtendedAccountPublicKey = wallet.KeyManager.SegwitExtPubKey.ToString(network);
@@ -47,5 +47,5 @@ public partial class WalletInfoModel
 
 	public string? ExtendedMasterZprv { get; }
 
-	public WpkhWalletPolicies? WpkhWalletPolicies { get; }
+	public WalletPolicy? WpkhWalletPolicy { get; }
 }

--- a/WalletWasabi.Fluent/Models/Wallets/WalletInfoModel.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/WalletInfoModel.cs
@@ -20,7 +20,7 @@ public partial class WalletInfoModel
 			ExtendedMasterZprv = secret.ToZPrv(network);
 
 			// TODO: Should work for every type of wallet, temporarily disabling it.
-			WpkhWalletPolicy = wallet.KeyManager.GetWpkhWalletPolicy(wallet.Password, network);
+			WpkhWalletPolicies = wallet.KeyManager.GetWpkhWalletPolicies(wallet.Password, network);
 		}
 
 		SegWitExtendedAccountPublicKey = wallet.KeyManager.SegwitExtPubKey.ToString(network);
@@ -47,5 +47,5 @@ public partial class WalletInfoModel
 
 	public string? ExtendedMasterZprv { get; }
 
-	public WalletPolicy? WpkhWalletPolicy { get; }
+	public WpkhWalletPolicies? WpkhWalletPolicies { get; }
 }

--- a/WalletWasabi.Fluent/Models/Wallets/WalletInfoModel.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/WalletInfoModel.cs
@@ -1,7 +1,8 @@
+using NBitcoin.WalletPolicies;
 using WalletWasabi.Extensions;
 using WalletWasabi.Userfacing;
 using WalletWasabi.Wallets;
-using static WalletWasabi.Blockchain.Keys.WpkhOutputDescriptorHelper;
+using static WalletWasabi.Blockchain.Keys.WpkhWalletPolicyHelper;
 
 namespace WalletWasabi.Fluent.Models.Wallets;
 
@@ -19,7 +20,7 @@ public partial class WalletInfoModel
 			ExtendedMasterZprv = secret.ToZPrv(network);
 
 			// TODO: Should work for every type of wallet, temporarily disabling it.
-			WpkhOutputDescriptors = wallet.KeyManager.GetOutputDescriptors(wallet.Password, network);
+			WpkhWalletPolicy = wallet.KeyManager.GetWpkhWalletPolicy(wallet.Password, network);
 		}
 
 		SegWitExtendedAccountPublicKey = wallet.KeyManager.SegwitExtPubKey.ToString(network);
@@ -46,5 +47,5 @@ public partial class WalletInfoModel
 
 	public string? ExtendedMasterZprv { get; }
 
-	public WpkhDescriptors? WpkhOutputDescriptors { get; }
+	public WalletPolicy? WpkhWalletPolicy { get; }
 }

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Advanced/WalletInfoViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Advanced/WalletInfoViewModel.cs
@@ -56,9 +56,10 @@ public partial class WalletInfoViewModel : RoutableViewModel
 
 	public string? ExtendedMasterZprv => _model.ExtendedMasterZprv;
 
-	public bool HasWpkhWalletPolicy => _model.WpkhWalletPolicy is not null;
+	public bool HasWpkhWalletPolicies => _model.WpkhWalletPolicies is not null;
 
-	public string? WpkhWalletPolicyFullDescriptor => _model.WpkhWalletPolicy?.FullDescriptor.ToString();
+	public string? WpkhWalletPrivatePolicyFullDescriptor => _model.WpkhWalletPolicies?.Private.FullDescriptor.ToString();
+	public string? WpkhWalletPublicPolicyFullDescriptor => _model.WpkhWalletPolicies?.Public.FullDescriptor.ToString();
 
 	public bool IsHardwareWallet { get; }
 }

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Advanced/WalletInfoViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Advanced/WalletInfoViewModel.cs
@@ -56,15 +56,9 @@ public partial class WalletInfoViewModel : RoutableViewModel
 
 	public string? ExtendedMasterZprv => _model.ExtendedMasterZprv;
 
-	public bool HasOutputDescriptors => _model.WpkhOutputDescriptors is not null;
+	public bool HasWpkhWalletPolicy => _model.WpkhWalletPolicy is not null;
 
-	public string? PublicExternalOutputDescriptor => _model.WpkhOutputDescriptors?.PublicExternal.ToString();
-
-	public string? PublicInternalOutputDescriptor => _model.WpkhOutputDescriptors?.PublicInternal.ToString();
-
-	public string? PrivateExternalOutputDescriptor => _model.WpkhOutputDescriptors?.PrivateExternal;
-
-	public string? PrivateInternalOutputDescriptor => _model.WpkhOutputDescriptors?.PrivateInternal;
+	public string? WpkhWalletPolicyFullDescriptor => _model.WpkhWalletPolicy?.FullDescriptor.ToString();
 
 	public bool IsHardwareWallet { get; }
 }

--- a/WalletWasabi.Fluent/ViewModels/Wallets/Advanced/WalletInfoViewModel.cs
+++ b/WalletWasabi.Fluent/ViewModels/Wallets/Advanced/WalletInfoViewModel.cs
@@ -56,10 +56,9 @@ public partial class WalletInfoViewModel : RoutableViewModel
 
 	public string? ExtendedMasterZprv => _model.ExtendedMasterZprv;
 
-	public bool HasWpkhWalletPolicies => _model.WpkhWalletPolicies is not null;
+	public bool HasWpkhWalletPolicy => _model.WpkhWalletPolicy is not null;
 
-	public string? WpkhWalletPrivatePolicyFullDescriptor => _model.WpkhWalletPolicies?.Private.FullDescriptor.ToString();
-	public string? WpkhWalletPublicPolicyFullDescriptor => _model.WpkhWalletPolicies?.Public.FullDescriptor.ToString();
+	public string? WpkhWalletPolicyFullDescriptor => _model.WpkhWalletPolicy?.FullDescriptor.ToString();
 
 	public bool IsHardwareWallet { get; }
 }

--- a/WalletWasabi.Fluent/Views/Wallets/Advanced/WalletInfoView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Advanced/WalletInfoView.axaml
@@ -69,34 +69,15 @@
       </PreviewItem>
       <Separator IsVisible="{Binding !!ExtendedAccountPrivateKey}" />
 
-      <StackPanel Spacing="10" IsVisible="{Binding HasOutputDescriptors}">
+      <StackPanel Spacing="10" IsVisible="{Binding HasWpkhWalletPolicy}">
         <PreviewItem Icon="{StaticResource key_regular}"
-                       Label="Public External Output descriptor"
-                       CopyableContent="{Binding PublicExternalOutputDescriptor}">
-          <PrivacyContentControl Classes="monoSpaced" Content="{Binding PublicExternalOutputDescriptor}" ForceShow="{Binding ShowSensitiveData}" />
-        </PreviewItem>
-        <PreviewItem Icon="{StaticResource key_regular}"
-                       Label="Public Internal Output descriptor"
-                       CopyableContent="{Binding PublicInternalOutputDescriptor}">
-          <PrivacyContentControl Classes="monoSpaced" Content="{Binding PublicInternalOutputDescriptor}" ForceShow="{Binding ShowSensitiveData}" />
-        </PreviewItem>
-
-        <PreviewItem Icon="{StaticResource key_regular}"
-                       Label="Private External Output descriptor"
-                       IsVisible="{Binding !!PrivateExternalOutputDescriptor}"
-                       PrivacyModeEnabled="{Binding !ShowSensitiveData}"
-                       CopyableContent="{Binding PrivateExternalOutputDescriptor}">
-          <PrivacyContentControl Classes="monoSpaced" Content="{Binding PrivateExternalOutputDescriptor}" ForceShow="{Binding ShowSensitiveData}" />
-        </PreviewItem>
-        <PreviewItem Icon="{StaticResource key_regular}"
-                       Label="Private Internal Output descriptor"
-                       IsVisible="{Binding !!PrivateInternalOutputDescriptor}"
-                       PrivacyModeEnabled="{Binding !ShowSensitiveData}"
-                       CopyableContent="{Binding PrivateInternalOutputDescriptor}">
-          <PrivacyContentControl Classes="monoSpaced" Content="{Binding PrivateInternalOutputDescriptor}" ForceShow="{Binding ShowSensitiveData}" />
+                     Label="Full Wallet Policy Descriptor"
+                     CopyableContent="{Binding WpkhWalletPolicyFullDescriptor}"
+                     PrivacyModeEnabled="{Binding !ShowSensitiveData}">
+          <PrivacyContentControl Classes="monoSpaced" Content="{Binding WpkhWalletPolicyFullDescriptor}" ForceShow="{Binding ShowSensitiveData}" />
         </PreviewItem>
       </StackPanel>
-      <Separator IsVisible="{Binding HasOutputDescriptors}" />
+      <Separator IsVisible="{Binding HasWpkhWalletPolicy}" />
 
       <PreviewItem Icon="{StaticResource key_regular}"
                      Label="Extended Account Public Key (SegWit)"

--- a/WalletWasabi.Fluent/Views/Wallets/Advanced/WalletInfoView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Advanced/WalletInfoView.axaml
@@ -61,10 +61,10 @@
       <Separator />
 
       <PreviewItem Icon="{StaticResource private_key_regular}"
-                     Label="Extended Account Private Key xpriv"
-                     CopyableContent="{Binding ExtendedAccountPrivateKey}"
-                     IsVisible="{Binding !!ExtendedAccountPrivateKey}"
-                     PrivacyModeEnabled="{Binding !ShowSensitiveData}">
+                   Label="Extended Account Private Key xpriv"
+                   CopyableContent="{Binding ExtendedAccountPrivateKey}"
+                   IsVisible="{Binding !!ExtendedAccountPrivateKey}"
+                   PrivacyModeEnabled="{Binding !ShowSensitiveData}">
         <TextBlock Classes="monoSpaced" Text="{Binding ExtendedAccountPrivateKey}" />
       </PreviewItem>
       <Separator IsVisible="{Binding !!ExtendedAccountPrivateKey}" />

--- a/WalletWasabi.Fluent/Views/Wallets/Advanced/WalletInfoView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Advanced/WalletInfoView.axaml
@@ -69,21 +69,15 @@
       </PreviewItem>
       <Separator IsVisible="{Binding !!ExtendedAccountPrivateKey}" />
 
-      <StackPanel Spacing="10" IsVisible="{Binding HasWpkhWalletPolicies}">
+      <StackPanel Spacing="10" IsVisible="{Binding HasWpkhWalletPolicy}">
         <PreviewItem Icon="{StaticResource key_regular}"
-                     Label="Private Wallet Policy"
-                     CopyableContent="{Binding WpkhWalletPrivatePolicyFullDescriptor}"
-                     PrivacyModeEnabled="{Binding !ShowSensitiveData}">
-          <PrivacyContentControl Classes="monoSpaced" Content="{Binding WpkhWalletPrivatePolicyFullDescriptor}" ForceShow="{Binding ShowSensitiveData}" />
-        </PreviewItem>
-        <PreviewItem Icon="{StaticResource key_regular}"
-                     Label="Public Wallet Policy"
-                     CopyableContent="{Binding WpkhWalletPublicPolicyFullDescriptor}">
-          <PrivacyContentControl Classes="monoSpaced" Content="{Binding WpkhWalletPublicPolicyFullDescriptor}" ForceShow="{Binding ShowSensitiveData}" />
+                     Label="WPKH Wallet Policy"
+                     CopyableContent="{Binding WpkhWalletPolicyFullDescriptor}">
+          <PrivacyContentControl Classes="monoSpaced" Content="{Binding WpkhWalletPolicyFullDescriptor}" ForceShow="{Binding ShowSensitiveData}" />
         </PreviewItem>
       </StackPanel>
 
-      <Separator IsVisible="{Binding HasWpkhWalletPolicies}" />
+      <Separator IsVisible="{Binding HasWpkhWalletPolicy}" />
 
       <PreviewItem Icon="{StaticResource key_regular}"
                      Label="Extended Account Public Key (SegWit)"

--- a/WalletWasabi.Fluent/Views/Wallets/Advanced/WalletInfoView.axaml
+++ b/WalletWasabi.Fluent/Views/Wallets/Advanced/WalletInfoView.axaml
@@ -69,15 +69,21 @@
       </PreviewItem>
       <Separator IsVisible="{Binding !!ExtendedAccountPrivateKey}" />
 
-      <StackPanel Spacing="10" IsVisible="{Binding HasWpkhWalletPolicy}">
+      <StackPanel Spacing="10" IsVisible="{Binding HasWpkhWalletPolicies}">
         <PreviewItem Icon="{StaticResource key_regular}"
-                     Label="Full Wallet Policy Descriptor"
-                     CopyableContent="{Binding WpkhWalletPolicyFullDescriptor}"
+                     Label="Private Wallet Policy"
+                     CopyableContent="{Binding WpkhWalletPrivatePolicyFullDescriptor}"
                      PrivacyModeEnabled="{Binding !ShowSensitiveData}">
-          <PrivacyContentControl Classes="monoSpaced" Content="{Binding WpkhWalletPolicyFullDescriptor}" ForceShow="{Binding ShowSensitiveData}" />
+          <PrivacyContentControl Classes="monoSpaced" Content="{Binding WpkhWalletPrivatePolicyFullDescriptor}" ForceShow="{Binding ShowSensitiveData}" />
+        </PreviewItem>
+        <PreviewItem Icon="{StaticResource key_regular}"
+                     Label="Public Wallet Policy"
+                     CopyableContent="{Binding WpkhWalletPublicPolicyFullDescriptor}">
+          <PrivacyContentControl Classes="monoSpaced" Content="{Binding WpkhWalletPublicPolicyFullDescriptor}" ForceShow="{Binding ShowSensitiveData}" />
         </PreviewItem>
       </StackPanel>
-      <Separator IsVisible="{Binding HasWpkhWalletPolicy}" />
+
+      <Separator IsVisible="{Binding HasWpkhWalletPolicies}" />
 
       <PreviewItem Icon="{StaticResource key_regular}"
                      Label="Extended Account Public Key (SegWit)"

--- a/WalletWasabi.Fluent/packages.lock.json
+++ b/WalletWasabi.Fluent/packages.lock.json
@@ -630,7 +630,7 @@
           "Microsoft.Extensions.Hosting.Abstractions": "[10.0.2, )",
           "Microsoft.Extensions.Http": "[10.0.2, )",
           "Microsoft.Win32.SystemEvents": "[10.0.2, )",
-          "NBitcoin": "[8.0.14, )",
+          "NBitcoin": "[9.0.5, )",
           "NNostr.Client": "[0.0.54, )",
           "System.Linq.Async": "[7.0.0, )",
           "WabiSabi": "[1.0.1.2, )"
@@ -720,9 +720,9 @@
       },
       "NBitcoin": {
         "type": "CentralTransitive",
-        "requested": "[8.0.14, )",
-        "resolved": "8.0.14",
-        "contentHash": "pRrgEC7HNvOvjGeqHWIOjz/S3OcQiJ7nLRDokreXU5VShfjXWkiOjt9aP/zswliPheRfcAQWFU/BjlMIgwBlLg==",
+        "requested": "[9.0.5, )",
+        "resolved": "9.0.5",
+        "contentHash": "twjb1YfGcOW2UaR+GWMDGMPKQgjwVyzARML4oGxSSZQO8CyzULel2ipOUC6nhCpP6XN1fVGNQmOWfbD5AI8ksw==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "1.0.0",
           "Newtonsoft.Json": "13.0.1"

--- a/WalletWasabi.Fluent/packages.lock.json
+++ b/WalletWasabi.Fluent/packages.lock.json
@@ -630,7 +630,7 @@
           "Microsoft.Extensions.Hosting.Abstractions": "[10.0.2, )",
           "Microsoft.Extensions.Http": "[10.0.2, )",
           "Microsoft.Win32.SystemEvents": "[10.0.2, )",
-          "NBitcoin": "[9.0.5, )",
+          "NBitcoin": "[10.0.3, )",
           "NNostr.Client": "[0.0.54, )",
           "System.Linq.Async": "[7.0.0, )",
           "WabiSabi": "[1.0.1.2, )"
@@ -720,9 +720,9 @@
       },
       "NBitcoin": {
         "type": "CentralTransitive",
-        "requested": "[9.0.5, )",
-        "resolved": "9.0.5",
-        "contentHash": "twjb1YfGcOW2UaR+GWMDGMPKQgjwVyzARML4oGxSSZQO8CyzULel2ipOUC6nhCpP6XN1fVGNQmOWfbD5AI8ksw==",
+        "requested": "[10.0.3, )",
+        "resolved": "10.0.3",
+        "contentHash": "nuzZn+IziBmZXySg+G48UT2g2YZ7SgjsK9qdIefkRjsbw2ddeQEXuoHFtvB0w2A6YlQgjio09g5Y5PnMHMfZwA==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "1.0.0",
           "Newtonsoft.Json": "13.0.1"

--- a/WalletWasabi.Tests/UnitTests/Blockchain/Keys/WpkhOutputDescriptorHelperTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Blockchain/Keys/WpkhOutputDescriptorHelperTests.cs
@@ -1,11 +1,11 @@
 using NBitcoin;
+using NBitcoin.WalletPolicies;
 using WalletWasabi.Blockchain.Keys;
-using WalletWasabi.Helpers;
 using Xunit;
 
 namespace WalletWasabi.Tests.UnitTests.Blockchain.Keys;
 
-public class WpkhOutputDescriptorHelperTests
+public class WpkhWalletPolicyHelperTests
 {
 	[Fact]
 	public void BasicTest()
@@ -17,10 +17,9 @@ public class WpkhOutputDescriptorHelperTests
 		KeyPath keyPath = new("84'/0'/0'");
 		HDFingerprint masterFingerprint = new(0x2fc4a4f3);
 
-		WpkhOutputDescriptorHelper.WpkhDescriptors descriptors = WpkhOutputDescriptorHelper.GetOutputDescriptors(testNet, masterFingerprint, accountPrivateKey, keyPath);
-		Assert.Equal("wpkh([f3a4c42f/84'/0'/0']tpubDDPaZ82MfnPUigb426fCAEvJnVT7AJgQLmxptzh9oyH59dGJYzsqkqvgj6SyY9eBHhFmG286cfj66Dzv1kYAnC3o7LRxohvo7mwWPr26uje/1/*)#z2666dqc", descriptors.PublicInternal.ToString());
-		Assert.Equal("wpkh([f3a4c42f/84'/0'/0']tpubDDPaZ82MfnPUigb426fCAEvJnVT7AJgQLmxptzh9oyH59dGJYzsqkqvgj6SyY9eBHhFmG286cfj66Dzv1kYAnC3o7LRxohvo7mwWPr26uje/0/*)#n7lm8csq", descriptors.PublicExternal.ToString());
-		Assert.Equal("wpkh([f3a4c42f/84'/0'/0']tprv8ghYQhz7XQhoqDZG8SzbkqGCDTwAzyVVmUN3cUerPhUgK91Xvc4FaMJpYwrjuQ48WD7KdQ7Y6znKnaY9PXP8SiDLv1srjjs8NVYGuM7Hrrk/1/*)#ktc4yfd7", descriptors.PrivateInternal);
-		Assert.Equal("wpkh([f3a4c42f/84'/0'/0']tprv8ghYQhz7XQhoqDZG8SzbkqGCDTwAzyVVmUN3cUerPhUgK91Xvc4FaMJpYwrjuQ48WD7KdQ7Y6znKnaY9PXP8SiDLv1srjjs8NVYGuM7Hrrk/0/*)#8la5euax", descriptors.PrivateExternal);
+		WalletPolicy walletPolicy = WpkhWalletPolicyHelper.Get(testNet, masterFingerprint, accountPrivateKey, keyPath);
+
+		string expected = "wpkh([f3a4c42f/84'/0'/0']tprv8ghYQhz7XQhoqDZG8SzbkqGCDTwAzyVVmUN3cUerPhUgK91Xvc4FaMJpYwrjuQ48WD7KdQ7Y6znKnaY9PXP8SiDLv1srjjs8NVYGuM7Hrrk/<0;1>/*)";
+		Assert.Equal(expected, walletPolicy.FullDescriptor.ToString());
 	}
 }

--- a/WalletWasabi.Tests/UnitTests/Blockchain/Keys/WpkhOutputDescriptorHelperTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Blockchain/Keys/WpkhOutputDescriptorHelperTests.cs
@@ -1,5 +1,4 @@
 using NBitcoin;
-using NBitcoin.WalletPolicies;
 using WalletWasabi.Blockchain.Keys;
 using Xunit;
 
@@ -10,16 +9,21 @@ public class WpkhWalletPolicyHelperTests
 	[Fact]
 	public void BasicTest()
 	{
-		Network testNet = Network.TestNet;
-		BitcoinEncryptedSecretNoEC encryptedSecret = new(wif: "6PYJxoa2SLZdYADFyMp3wo41RKaKGNedC3vviix4VdjFfrt1LkKDmXmYTM", Network.Main);
-		byte[]? chainCode = Convert.FromHexString("D9DAD5377AB84A44815403FF57B0ABC6825701560DAA0F0FCDDB5A52EBE12A6E");
-		ExtKey accountPrivateKey = new(encryptedSecret.GetKey(password: "123456"), chainCode);
-		KeyPath keyPath = new("84'/0'/0'");
-		HDFingerprint masterFingerprint = new(0x2fc4a4f3);
+		var testNet = Network.TestNet;
+		var encryptedSecret = new BitcoinEncryptedSecretNoEC(wif: "6PYJxoa2SLZdYADFyMp3wo41RKaKGNedC3vviix4VdjFfrt1LkKDmXmYTM", Network.Main);
+		var chainCode = Convert.FromHexString("D9DAD5377AB84A44815403FF57B0ABC6825701560DAA0F0FCDDB5A52EBE12A6E");
+		var accountPrivateKey = new ExtKey(encryptedSecret.GetKey(password: "123456"), chainCode);
+		var keyPath = new KeyPath("84'/0'/0'");
+		var masterFingerprint = new HDFingerprint(0x2fc4a4f3);
 
-		WalletPolicy walletPolicy = WpkhWalletPolicyHelper.Get(testNet, masterFingerprint, accountPrivateKey, keyPath);
+		var walletPolicies = WpkhWalletPolicyHelper.Get(testNet, masterFingerprint, accountPrivateKey, keyPath);
 
-		string expected = "wpkh([f3a4c42f/84'/0'/0']tprv8ghYQhz7XQhoqDZG8SzbkqGCDTwAzyVVmUN3cUerPhUgK91Xvc4FaMJpYwrjuQ48WD7KdQ7Y6znKnaY9PXP8SiDLv1srjjs8NVYGuM7Hrrk/<0;1>/*)";
-		Assert.Equal(expected, walletPolicy.FullDescriptor.ToString());
+		var expected = "wpkh([f3a4c42f/84'/0'/0']tprv8ghYQhz7XQhoqDZG8SzbkqGCDTwAzyVVmUN3cUerPhUgK91Xvc4FaMJpYwrjuQ48WD7KdQ7Y6znKnaY9PXP8SiDLv1srjjs8NVYGuM7Hrrk/<0;1>/*)";
+		var actual = walletPolicies.Private.FullDescriptor.ToString();
+		Assert.Equal(expected, actual);
+
+		expected = "wpkh([f3a4c42f/84'/0'/0']tpubDDPaZ82MfnPUigb426fCAEvJnVT7AJgQLmxptzh9oyH59dGJYzsqkqvgj6SyY9eBHhFmG286cfj66Dzv1kYAnC3o7LRxohvo7mwWPr26uje/<0;1>/*)";
+		actual = walletPolicies.Public.FullDescriptor.ToString();
+		Assert.Equal(expected, actual);
 	}
 }

--- a/WalletWasabi.Tests/UnitTests/Blockchain/Keys/WpkhOutputDescriptorHelperTests.cs
+++ b/WalletWasabi.Tests/UnitTests/Blockchain/Keys/WpkhOutputDescriptorHelperTests.cs
@@ -16,14 +16,10 @@ public class WpkhWalletPolicyHelperTests
 		var keyPath = new KeyPath("84'/0'/0'");
 		var masterFingerprint = new HDFingerprint(0x2fc4a4f3);
 
-		var walletPolicies = WpkhWalletPolicyHelper.Get(testNet, masterFingerprint, accountPrivateKey, keyPath);
+		var walletPolicy = WpkhWalletPolicyHelper.Get(testNet, masterFingerprint, accountPrivateKey, keyPath);
 
-		var expected = "wpkh([f3a4c42f/84'/0'/0']tprv8ghYQhz7XQhoqDZG8SzbkqGCDTwAzyVVmUN3cUerPhUgK91Xvc4FaMJpYwrjuQ48WD7KdQ7Y6znKnaY9PXP8SiDLv1srjjs8NVYGuM7Hrrk/<0;1>/*)";
-		var actual = walletPolicies.Private.FullDescriptor.ToString();
-		Assert.Equal(expected, actual);
-
-		expected = "wpkh([f3a4c42f/84'/0'/0']tpubDDPaZ82MfnPUigb426fCAEvJnVT7AJgQLmxptzh9oyH59dGJYzsqkqvgj6SyY9eBHhFmG286cfj66Dzv1kYAnC3o7LRxohvo7mwWPr26uje/<0;1>/*)";
-		actual = walletPolicies.Public.FullDescriptor.ToString();
+		var expected = "wpkh([f3a4c42f/84'/0'/0']tpubDDPaZ82MfnPUigb426fCAEvJnVT7AJgQLmxptzh9oyH59dGJYzsqkqvgj6SyY9eBHhFmG286cfj66Dzv1kYAnC3o7LRxohvo7mwWPr26uje/<0;1>/*)";
+		var actual = walletPolicy.FullDescriptor.ToString();
 		Assert.Equal(expected, actual);
 	}
 }

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/ArenaClientTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/ArenaClientTests.cs
@@ -110,7 +110,7 @@ public class ArenaClientTests
 		var finalizedEmptyState = new SigningState(round.Parameters, emptyState.Events);
 
 		// No inputs in the coinjoin.
-		await Assert.ThrowsAsync<InvalidOperationException>(async () =>
+		await Assert.ThrowsAsync<ArgumentException>(async () =>
 				await apiClient.SignTransactionAsync(round.Id, alice1.Coin, keyChain, finalizedEmptyState.CreateUnsignedTransactionWithPrecomputedData(), CancellationToken.None));
 
 		var oneInput = emptyState.AddInput(alice1.Coin, alice1.OwnershipProof, commitmentData).Finalize();

--- a/WalletWasabi.Tests/UnitTests/WabiSabi/Client/KeyChainTests.cs
+++ b/WalletWasabi.Tests/UnitTests/WabiSabi/Client/KeyChainTests.cs
@@ -22,10 +22,10 @@ public class KeyChainTests
 
 		var transaction = Transaction.Create(Network.Main); // the transaction doesn't contain the input that we request to be signed.
 
-		Assert.Throws<InvalidOperationException>(() => keyChain.Sign(transaction, coin, transaction.PrecomputeTransactionData()));
+		Assert.Throws<ArgumentException>(() => keyChain.Sign(transaction, coin, transaction.PrecomputeTransactionData()));
 
 		transaction.Inputs.Add(coin.Outpoint);
-		var signedTx = keyChain.Sign(transaction, coin, transaction.PrecomputeTransactionData(new[] { coin }));
+		var signedTx = keyChain.Sign(transaction, coin, transaction.PrecomputeTransactionData([coin]));
 		Assert.True(signedTx.HasWitness);
 	}
 }

--- a/WalletWasabi/Blockchain/Keys/KeyManager.cs
+++ b/WalletWasabi/Blockchain/Keys/KeyManager.cs
@@ -1,5 +1,6 @@
 using NBitcoin;
 using NBitcoin.Secp256k1;
+using NBitcoin.WalletPolicies;
 using System.Collections.Generic;
 using System.Data;
 using System.Diagnostics.CodeAnalysis;
@@ -147,7 +148,7 @@ public class KeyManager
 			_ => throw new ArgumentException($"Unknown account for network '{network}' and key purpose.")
 		});
 
-	public WpkhWalletPolicies GetWpkhWalletPolicies(string password, Network network)
+	public WalletPolicy GetWpkhWalletPolicy(string password, Network network)
 	{
 		if (!MasterFingerprint.HasValue)
 		{

--- a/WalletWasabi/Blockchain/Keys/KeyManager.cs
+++ b/WalletWasabi/Blockchain/Keys/KeyManager.cs
@@ -20,11 +20,11 @@ using WalletWasabi.Serialization;
 using WalletWasabi.Wallets;
 using WalletWasabi.Wallets.SilentPayment;
 using WalletWasabi.Wallets.Slip39;
-using static WalletWasabi.Blockchain.Keys.WpkhOutputDescriptorHelper;
 using Decode = WalletWasabi.Serialization.Decode;
 using Encode = WalletWasabi.Serialization.Encode;
 using Network = NBitcoin.Network;
 using OutPoint = NBitcoin.OutPoint;
+using NBitcoin.WalletPolicies;
 
 namespace WalletWasabi.Blockchain.Keys;
 
@@ -147,14 +147,14 @@ public class KeyManager
 			_ => throw new ArgumentException($"Unknown account for network '{network}' and key purpose.")
 		});
 
-	public WpkhDescriptors GetOutputDescriptors(string password, Network network)
+	public WalletPolicy GetWpkhWalletPolicy(string password, Network network)
 	{
 		if (!MasterFingerprint.HasValue)
 		{
 			throw new InvalidOperationException($"{nameof(MasterFingerprint)} is not defined.");
 		}
 
-		return WpkhOutputDescriptorHelper.GetOutputDescriptors(network, MasterFingerprint.Value, GetMasterExtKey(password), SegwitAccountKeyPath);
+		return WpkhWalletPolicyHelper.Get(network, MasterFingerprint.Value, GetMasterExtKey(password), SegwitAccountKeyPath);
 	}
 
 	#region Properties

--- a/WalletWasabi/Blockchain/Keys/KeyManager.cs
+++ b/WalletWasabi/Blockchain/Keys/KeyManager.cs
@@ -1,4 +1,5 @@
 using NBitcoin;
+using NBitcoin.Secp256k1;
 using System.Collections.Generic;
 using System.Data;
 using System.Diagnostics.CodeAnalysis;
@@ -7,7 +8,6 @@ using System.Linq;
 using System.Security;
 using System.Text;
 using System.Text.Json.Nodes;
-using NBitcoin.Secp256k1;
 using WalletWasabi.Blockchain.Analysis.Clustering;
 using WalletWasabi.Blockchain.BlockFilters;
 using WalletWasabi.CoinJoinProfiles;
@@ -20,11 +20,11 @@ using WalletWasabi.Serialization;
 using WalletWasabi.Wallets;
 using WalletWasabi.Wallets.SilentPayment;
 using WalletWasabi.Wallets.Slip39;
+using static WalletWasabi.Blockchain.Keys.WpkhWalletPolicyHelper;
 using Decode = WalletWasabi.Serialization.Decode;
 using Encode = WalletWasabi.Serialization.Encode;
 using Network = NBitcoin.Network;
 using OutPoint = NBitcoin.OutPoint;
-using NBitcoin.WalletPolicies;
 
 namespace WalletWasabi.Blockchain.Keys;
 
@@ -147,7 +147,7 @@ public class KeyManager
 			_ => throw new ArgumentException($"Unknown account for network '{network}' and key purpose.")
 		});
 
-	public WalletPolicy GetWpkhWalletPolicy(string password, Network network)
+	public WpkhWalletPolicies GetWpkhWalletPolicies(string password, Network network)
 	{
 		if (!MasterFingerprint.HasValue)
 		{

--- a/WalletWasabi/Blockchain/Keys/WpkhOutputDescriptorHelper.cs
+++ b/WalletWasabi/Blockchain/Keys/WpkhOutputDescriptorHelper.cs
@@ -1,5 +1,5 @@
-using NBitcoin.Scripting;
 using NBitcoin;
+using NBitcoin.Scripting;
 
 namespace WalletWasabi.Blockchain.Keys;
 

--- a/WalletWasabi/Blockchain/Keys/WpkhOutputDescriptorHelper.cs
+++ b/WalletWasabi/Blockchain/Keys/WpkhOutputDescriptorHelper.cs
@@ -6,24 +6,17 @@ namespace WalletWasabi.Blockchain.Keys;
 public class WpkhWalletPolicyHelper
 {
 	/// <seealso href="https://bips.dev/388/"/>
-	public static WpkhWalletPolicies Get(Network network, HDFingerprint masterFingerprint, ExtKey notDerivedAccountKey, KeyPath accountKeyPath)
+	public static WalletPolicy Get(Network network, HDFingerprint masterFingerprint, ExtKey notDerivedAccountKey, KeyPath accountKeyPath)
 	{
-		ExtKey accountKey = notDerivedAccountKey.Derive(accountKeyPath);
+		var accountKey = notDerivedAccountKey.Derive(accountKeyPath);
 
 		// Optional part looks like this, for example: [2fc4a4f3/84'/0'/0']
-		string optionalPart = $"[{masterFingerprint}/{accountKeyPath}]";
+		var optionalPart = $"[{masterFingerprint}/{accountKeyPath}]";
 
-		// Optional part is followed by the actual private key: "tprv8ghYQhz7XQhoqDZG8SzbkqGCDTwAzyVVmUN3cUerPhUgK91Xvc4FaMJpYwrjuQ48WD7KdQ7Y6znKnaY9PXP8SiDLv1srjjs8NVYGuM7Hrrk"
-		string privateDescriptor = $"{optionalPart}{accountKey.ToString(network)}";
-		WalletPolicy privateWalletPolicy = WalletPolicy.Parse($"wpkh({privateDescriptor}/<0;1>/*)", network);
+		// Optional part is followed by the actual public key: "tprv8ghYQhz7XQhoqDZG8SzbkqGCDTwAzyVVmUN3cUerPhUgK91Xvc4FaMJpYwrjuQ48WD7KdQ7Y6znKnaY9PXP8SiDLv1srjjs8NVYGuM7Hrrk"
+		var extPubKey = accountKey.Neuter();
+		var publicDescriptor = $"{optionalPart}{extPubKey.ToString(network)}";
 
-		// Get xpub.
-		ExtPubKey extPubKey = accountKey.Neuter();
-		string publicDescriptor = $"{optionalPart}{extPubKey.ToString(network)}";
-		WalletPolicy publicWalletPolicy = WalletPolicy.Parse($"wpkh({publicDescriptor}/<0;1>/*)", network);
-
-		return new WpkhWalletPolicies(privateWalletPolicy, publicWalletPolicy);
+		return WalletPolicy.Parse($"wpkh({publicDescriptor}/<0;1>/*)", network);
 	}
-
-	public record WpkhWalletPolicies(WalletPolicy Private, WalletPolicy Public);
 }

--- a/WalletWasabi/Blockchain/Keys/WpkhOutputDescriptorHelper.cs
+++ b/WalletWasabi/Blockchain/Keys/WpkhOutputDescriptorHelper.cs
@@ -6,7 +6,7 @@ namespace WalletWasabi.Blockchain.Keys;
 public class WpkhWalletPolicyHelper
 {
 	/// <seealso href="https://bips.dev/388/"/>
-	public static WalletPolicy Get(Network network, HDFingerprint masterFingerprint, ExtKey notDerivedAccountKey, KeyPath accountKeyPath)
+	public static WpkhWalletPolicies Get(Network network, HDFingerprint masterFingerprint, ExtKey notDerivedAccountKey, KeyPath accountKeyPath)
 	{
 		ExtKey accountKey = notDerivedAccountKey.Derive(accountKeyPath);
 
@@ -15,9 +15,15 @@ public class WpkhWalletPolicyHelper
 
 		// Optional part is followed by the actual private key: "tprv8ghYQhz7XQhoqDZG8SzbkqGCDTwAzyVVmUN3cUerPhUgK91Xvc4FaMJpYwrjuQ48WD7KdQ7Y6znKnaY9PXP8SiDLv1srjjs8NVYGuM7Hrrk"
 		string privateDescriptor = $"{optionalPart}{accountKey.ToString(network)}";
+		WalletPolicy privateWalletPolicy = WalletPolicy.Parse($"wpkh({privateDescriptor}/<0;1>/*)", network);
 
-		WalletPolicy walletPolicy = WalletPolicy.Parse($"wpkh({privateDescriptor}/<0;1>/*)", network);
+		// Get xpub.
+		ExtPubKey extPubKey = accountKey.Neuter();
+		string publicDescriptor = $"{optionalPart}{extPubKey.ToString(network)}";
+		WalletPolicy publicWalletPolicy = WalletPolicy.Parse($"wpkh({publicDescriptor}/<0;1>/*)", network);
 
-		return walletPolicy;
+		return new WpkhWalletPolicies(privateWalletPolicy, publicWalletPolicy);
 	}
+
+	public record WpkhWalletPolicies(WalletPolicy Private, WalletPolicy Public);
 }

--- a/WalletWasabi/Blockchain/Keys/WpkhOutputDescriptorHelper.cs
+++ b/WalletWasabi/Blockchain/Keys/WpkhOutputDescriptorHelper.cs
@@ -1,12 +1,12 @@
 using NBitcoin;
-using NBitcoin.Scripting;
+using NBitcoin.WalletPolicies;
 
 namespace WalletWasabi.Blockchain.Keys;
 
-public class WpkhOutputDescriptorHelper
+public class WpkhWalletPolicyHelper
 {
-	/// <seealso href="https://github.com/bitcoin/bitcoin/blob/master/doc/descriptors.md#reference"/>
-	public static WpkhDescriptors GetOutputDescriptors(Network network, HDFingerprint masterFingerprint, ExtKey notDerivedAccountKey, KeyPath accountKeyPath)
+	/// <seealso href="https://bips.dev/388/"/>
+	public static WalletPolicy Get(Network network, HDFingerprint masterFingerprint, ExtKey notDerivedAccountKey, KeyPath accountKeyPath)
 	{
 		ExtKey accountKey = notDerivedAccountKey.Derive(accountKeyPath);
 
@@ -16,25 +16,8 @@ public class WpkhOutputDescriptorHelper
 		// Optional part is followed by the actual private key: "tprv8ghYQhz7XQhoqDZG8SzbkqGCDTwAzyVVmUN3cUerPhUgK91Xvc4FaMJpYwrjuQ48WD7KdQ7Y6znKnaY9PXP8SiDLv1srjjs8NVYGuM7Hrrk"
 		string privateDescriptor = $"{optionalPart}{accountKey.ToString(network)}";
 
-		FlatSigningRepository internalRepo = new();
-		FlatSigningRepository externalRepo = new();
+		WalletPolicy walletPolicy = WalletPolicy.Parse($"wpkh({privateDescriptor}/<0;1>/*)", network);
 
-		// Descriptor for all unhardened children (`/*`)
-		OutputDescriptor internalPublicDescriptor = OutputDescriptor.Parse($"wpkh({privateDescriptor}/1/*)", network, requireCheckSum: false, internalRepo);
-		OutputDescriptor externalPublicDescriptor = OutputDescriptor.Parse($"wpkh({privateDescriptor}/0/*)", network, requireCheckSum: false, externalRepo);
-
-		externalPublicDescriptor.TryGetPrivateString(externalRepo, out string? privateExternalDescriptor);
-		internalPublicDescriptor.TryGetPrivateString(internalRepo, out string? privateInternalDescriptor);
-
-		return new(internalPublicDescriptor, externalPublicDescriptor, privateInternalDescriptor, privateExternalDescriptor);
+		return walletPolicy;
 	}
-
-	/// <summary>
-	/// Set of public and private + internal and external descriptors.
-	/// </summary>
-	/// <param name="PublicInternal">Descriptor describing something like:   <c>wpkh([2fc4a4f3/84'/0'/0']tpubDDPaZ82MfnPUigb426fCAEvJnVT7AJgQLmxptzh9oyH59dGJYzsqkqvgj6SyY9eBHhFmG286cfj66Dzv1kYAnC3o7LRxohvo7mwWPr26uje/1/*)#wjx95ths</c>.</param>
-	/// <param name="PublicExternal">Descriptor describing something like:   <c>wpkh([2fc4a4f3/84'/0'/0']tpubDDPaZ82MfnPUigb426fCAEvJnVT7AJgQLmxptzh9oyH59dGJYzsqkqvgj6SyY9eBHhFmG286cfj66Dzv1kYAnC3o7LRxohvo7mwWPr26uje/0/*)#lxryf78g</c>.</param>
-	/// <param name="PrivateInternal">A string similar to the following one: <c>wpkh([2fc4a4f3/84'/0'/0']tprv8ghYQhz7XQhoqDZG8SzbkqGCDTwAzyVVmUN3cUerPhUgK91Xvc4FaMJpYwrjuQ48WD7KdQ7Y6znKnaY9PXP8SiDLv1srjjs8NVYGuM7Hrrk/1/*)#6ny2206k</c>.</param>
-	/// <param name="PrivateExternal">A string similar to the following one: <c>wpkh([2fc4a4f3/84'/0'/0']tprv8ghYQhz7XQhoqDZG8SzbkqGCDTwAzyVVmUN3cUerPhUgK91Xvc4FaMJpYwrjuQ48WD7KdQ7Y6znKnaY9PXP8SiDLv1srjjs8NVYGuM7Hrrk/0/*)#t8pth62w</c>.</param>
-	public record WpkhDescriptors(OutputDescriptor PublicInternal, OutputDescriptor PublicExternal, string? PrivateInternal, string? PrivateExternal);
 }

--- a/WalletWasabi/packages.lock.json
+++ b/WalletWasabi/packages.lock.json
@@ -72,9 +72,9 @@
       },
       "NBitcoin": {
         "type": "Direct",
-        "requested": "[9.0.5, )",
-        "resolved": "9.0.5",
-        "contentHash": "twjb1YfGcOW2UaR+GWMDGMPKQgjwVyzARML4oGxSSZQO8CyzULel2ipOUC6nhCpP6XN1fVGNQmOWfbD5AI8ksw==",
+        "requested": "[10.0.3, )",
+        "resolved": "10.0.3",
+        "contentHash": "nuzZn+IziBmZXySg+G48UT2g2YZ7SgjsK9qdIefkRjsbw2ddeQEXuoHFtvB0w2A6YlQgjio09g5Y5PnMHMfZwA==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "1.0.0",
           "Newtonsoft.Json": "13.0.1"

--- a/WalletWasabi/packages.lock.json
+++ b/WalletWasabi/packages.lock.json
@@ -72,9 +72,9 @@
       },
       "NBitcoin": {
         "type": "Direct",
-        "requested": "[8.0.14, )",
-        "resolved": "8.0.14",
-        "contentHash": "pRrgEC7HNvOvjGeqHWIOjz/S3OcQiJ7nLRDokreXU5VShfjXWkiOjt9aP/zswliPheRfcAQWFU/BjlMIgwBlLg==",
+        "requested": "[9.0.5, )",
+        "resolved": "9.0.5",
+        "contentHash": "twjb1YfGcOW2UaR+GWMDGMPKQgjwVyzARML4oGxSSZQO8CyzULel2ipOUC6nhCpP6XN1fVGNQmOWfbD5AI8ksw==",
         "dependencies": {
           "Microsoft.Extensions.Logging.Abstractions": "1.0.0",
           "Newtonsoft.Json": "13.0.1"

--- a/deps.json
+++ b/deps.json
@@ -115,11 +115,6 @@
     "hash": "sha256-ZDNqbc2Rq1Sf7PvTPM+pDog7Lv4vcz2013EOe57w5FA="
   },
   {
-    "pname": "Castle.Core",
-    "version": "5.1.1",
-    "hash": "sha256-oVkQB+ON7S6Q27OhXrTLaxTL0kWB58HZaFFuiw4iTrE="
-  },
-  {
     "pname": "ColorDocument.Avalonia",
     "version": "11.0.3-a1",
     "hash": "sha256-Pkh5FX+4pBzep5oCCyhIiR559QyFCEb1vrfEgG0wREw="
@@ -560,14 +555,9 @@
     "hash": "sha256-zcL1+QbI452viyARfy6kNsdOuR2dRR86ex9vmAY81T8="
   },
   {
-    "pname": "Moq",
-    "version": "4.18.4",
-    "hash": "sha256-JOmYlcTJdQOthRxnT0jAD6WG+NVLMmIV2BM9rNhNg3Q="
-  },
-  {
     "pname": "NBitcoin",
-    "version": "8.0.14",
-    "hash": "sha256-Ut/0TdRutL5dljFhsUyrTISqyWe+rBuciKvC7ORBGqc="
+    "version": "10.0.3",
+    "hash": "sha256-jX5gKpVucJiIAs42UtbCl8Qt05WN/NVBQFWg85nIa5M="
   },
   {
     "pname": "NBitcoin.Secp256k1",
@@ -803,11 +793,6 @@
     "pname": "System.Diagnostics.EventLog",
     "version": "10.0.2",
     "hash": "sha256-rezZk0M4+MWRxwGSFzXfvekrhL8qLTp7Pc8YsSy/4nE="
-  },
-  {
-    "pname": "System.Diagnostics.EventLog",
-    "version": "6.0.0",
-    "hash": "sha256-zUXIQtAFKbiUMKCrXzO4mOTD5EUphZzghBYKXprowSM="
   },
   {
     "pname": "System.Diagnostics.FileVersionInfo",


### PR DESCRIPTION
The motivation for this PR was https://github.com/WalletWasabi/WalletWasabi/pull/14505#issuecomment-4338922214. I noticed that there are some changes for peer-related code:

https://github.com/MetacoSA/NBitcoin/commit/b3cdd932ba07ecf6f890ffe05fceca98f6424da0

so I figured I would upgrade NBitcoin first and then go to the original issue.

Unfortunately, there are two commits in NBitcoin 10[^1] that makes upgrading not so smooth:

* https://github.com/MetacoSA/NBitcoin/commit/333e746825baa12a89b0cb760fba4bbe42489d95
* https://github.com/MetacoSA/NBitcoin/commit/2f9f73e8f0ebbb52919c2d9cde53a5fab2a0db86

There is also:

* https://github.com/MetacoSA/NBitcoin/commit/a3e75b23ea5c53af0fbe13ab2e4217eaefccfb0d - Allow Transactions without inputs to always be cloned and serialized if segwit not supported.

### Sparrow Wallet

1. Download https://www.sparrowwallet.com/download/ for your OS.
2. In Wasabi, go to "Wallet Info", copy a Wallet Policy (public / private), store it to a text file (as a one line)
3. In Sparrow, click in menu: File -> Import Wallet -> Output Descriptor -> select the text file

-> You should see all your transactions.

### Unit Test

Setting `xprivPolicy` and `xpubPolicy` from Wallet should generate the same addresses for you. 

```cs
using NBitcoin;
using NBitcoin.WalletPolicies;
using Xunit;

namespace WalletWasabi.Tests.UnitTests.Blockchain.Keys;

public class WpkhWalletPolicyHelperTests
{
	[Fact]
	public void DeriveAddresses()
	{
		var network = Network.Main;
		var xprivPolicy = "wpkh(...)";
		var xpubPolicy = "wpkh(...)";

		var privateWalletPolicy = WalletPolicy.Parse(xprivPolicy, network);
		var publicWalletPolicy = WalletPolicy.Parse(xpubPolicy, network);

		for (int i = 0; i < 5; i++)
		{
			BitcoinAddress addrPriv = DeriveAddress(privateWalletPolicy, AddressIntent.Deposit, i, network);
			BitcoinAddress addrPub = DeriveAddress(publicWalletPolicy, AddressIntent.Deposit, i, network);
			Assert.Equal(addrPriv, addrPub);
		}
	}

	public BitcoinAddress DeriveAddress(WalletPolicy walletPolicy, AddressIntent addressIntent, int index, Network network)
	{
		Miniscript.Scripts expectedScripts = walletPolicy.FullDescriptor.Derive(addressIntent, index).Miniscript.ToScripts();
		BitcoinAddress? result = expectedScripts.ScriptPubKey.GetDestinationAddress(network);
		Assert.NotNull(result);

		return result;
	}
}
```

[^1]: Upgrading to NBitcoin 9 does not require code changes.