### PR TITLE
SortableItemDesign: Fix warnings

### DIFF
--- a/WalletWasabi.Fluent/Controls/Sorting/SortableItemDesign.cs
+++ b/WalletWasabi.Fluent/Controls/Sorting/SortableItemDesign.cs
@@ -4,9 +4,9 @@ namespace WalletWasabi.Fluent.Controls.Sorting;
 
 public class SortableItemDesign : ISortableItem
 {
-	public ICommand SortByDescendingCommand { get; set; }
-	public ICommand SortByAscendingCommand { get; set; }
-	public string Name { get; set; }
+	public ICommand SortByDescendingCommand { get; set; } = null!;
+	public ICommand SortByAscendingCommand { get; set; } = null!;
+	public string Name { get; set; } = null!;
 	public bool IsDescendingActive { get; set; }
 	public bool IsAscendingActive { get; set; }
 }


### PR DESCRIPTION
23 warnings -> 20 warnings

The `SortableItemDesign` class is used only in an Avalonia designer. So warnings can be simply suppressed.