### PR TITLE
Sync block headers

### DIFF
--- a/WalletWasabi.Client/Global.cs
+++ b/WalletWasabi.Client/Global.cs
@@ -185,6 +185,19 @@ public class Global
 			.Match(
 				bytes => new ConcurrentChain(bytes, Network),
 				_ => new ConcurrentChain(Network));
+
+		var blockHeaderSaver = Spawn("Block Headers persistence",
+			Service("Bitcoin Block Headers persistence",
+				Periodically(
+					TimeSpan.FromSeconds(30),
+					Unit.Instance,
+					async (Unit _, Unit _, CancellationToken ct) =>
+					{
+						await File.WriteAllBytesAsync(blockHeadersFilePath, blockHeaders.ToBytes(), ct);
+						return Unit.Instance;
+					})));
+		blockHeaderSaver.DisposeUsing(_disposables);
+		EventBus.Subscribe<Tick>(_ => blockHeaderSaver.Post(Unit.Instance));
 		return blockHeaders;
 	}
 

--- a/WalletWasabi.Client/Global.cs
+++ b/WalletWasabi.Client/Global.cs
@@ -151,8 +151,6 @@ public class Global
 
 	private NodesGroup ConfigureNodesGroup(MempoolService mempoolService)
 	{
-		var behavior = new P2pBehavior(mempoolService);
-
 		// NBitcoin doesn't have these dnsSeeds for signet
 		if (Network == Bitcoin.Instance.Signet)
 		{
@@ -163,13 +161,16 @@ public class Global
 			}
 		}
 
+		var p2PBehavior = new P2pBehavior(mempoolService);
+		var chainBehavior = new ChainBehavior(new ConcurrentChain());
+
 		var nodesGroup = Network == Network.RegTest
-			? P2pNetwork.CreateNodesGroupForRegTest(behavior)
+			? P2pNetwork.CreateNodesGroupForRegTest(p2PBehavior)
 			: P2pNetwork.CreateNodesGroup(
 				Network,
 				Config.UseTor != TorMode.Disabled ? TorSettings.SocksEndpoint : null,
 				GetBitcoinP2pNetworkDirectory(),
-				Config.BlockOnlyMode ? null : behavior);
+				Config.BlockOnlyMode ? [chainBehavior] : [chainBehavior, p2PBehavior]);
 
 		return nodesGroup;
 	}

--- a/WalletWasabi.Client/Global.cs
+++ b/WalletWasabi.Client/Global.cs
@@ -161,22 +161,31 @@ public class Global
 			}
 		}
 
-		var p2pDataDir = GetBitcoinP2pNetworkDirectory();
-
-		var p2PBehavior = new P2pBehavior(mempoolService);
-		var chainBehavior = new ChainBehavior(new ConcurrentChain());
-		var blockHeaders = new ConcurrentChain();
+		var p2PDataDir = GetBitcoinP2pNetworkDirectory();
+		var blockHeaders = LoadBlockHeaders(p2PDataDir);
 		var chainBehavior = new ChainBehavior(blockHeaders);
+		var p2PBehavior = new P2pBehavior(mempoolService);
 
 		var nodesGroup = Network == Network.RegTest
 			? P2pNetwork.CreateNodesGroupForRegTest(p2PBehavior)
 			: P2pNetwork.CreateNodesGroup(
 				Network,
 				Config.UseTor != TorMode.Disabled ? TorSettings.SocksEndpoint : null,
-				p2pDataDir,
+				p2PDataDir,
 				Config.BlockOnlyMode ? [chainBehavior] : [chainBehavior, p2PBehavior]);
 
 		return nodesGroup;
+	}
+
+	private ConcurrentChain LoadBlockHeaders(string p2PDataDir)
+	{
+		var blockHeadersFilePath = Path.Combine(p2PDataDir, $"BlockHeaders{Network}.dat");
+		var blockHeaders = Result<byte[], Exception>
+			.Catch(() => File.ReadAllBytes(blockHeadersFilePath))
+			.Match(
+				bytes => new ConcurrentChain(bytes, Network),
+				_ => new ConcurrentChain(Network));
+		return blockHeaders;
 	}
 
 	private void ConfigureBitcoinNetwork()

--- a/WalletWasabi.Client/Global.cs
+++ b/WalletWasabi.Client/Global.cs
@@ -161,15 +161,19 @@ public class Global
 			}
 		}
 
+		var p2pDataDir = GetBitcoinP2pNetworkDirectory();
+
 		var p2PBehavior = new P2pBehavior(mempoolService);
 		var chainBehavior = new ChainBehavior(new ConcurrentChain());
+		var blockHeaders = new ConcurrentChain();
+		var chainBehavior = new ChainBehavior(blockHeaders);
 
 		var nodesGroup = Network == Network.RegTest
 			? P2pNetwork.CreateNodesGroupForRegTest(p2PBehavior)
 			: P2pNetwork.CreateNodesGroup(
 				Network,
 				Config.UseTor != TorMode.Disabled ? TorSettings.SocksEndpoint : null,
-				GetBitcoinP2pNetworkDirectory(),
+				p2pDataDir,
 				Config.BlockOnlyMode ? [chainBehavior] : [chainBehavior, p2PBehavior]);
 
 		return nodesGroup;

--- a/WalletWasabi/BitcoinP2p/P2pNetwork.cs
+++ b/WalletWasabi/BitcoinP2p/P2pNetwork.cs
@@ -40,7 +40,7 @@ public static class P2pNetwork
 		}
 	}
 
-	public static NodesGroup CreateNodesGroup(Network network, EndPoint? torSocks5EndPoint, string workDir, P2pBehavior? p2PBehavior = null)
+	public static NodesGroup CreateNodesGroup(Network network, EndPoint? torSocks5EndPoint, string workDir, NodeBehavior[] behaviors)
 	{
 		var addressManagerFilePath = Path.Combine(workDir, $"AddressManager{network}.dat");
 		var connectionParameters = new NodeConnectionParameters();
@@ -59,9 +59,9 @@ public static class P2pNetwork
 		connectionParameters.TemplateBehaviors.Add(addressManagerBehavior);
 		connectionParameters.EndpointConnector = new BestEffortEndpointConnector(MaximumNodeConnections / 2);
 
-		if (p2PBehavior is not null)
+		foreach (var behavior in behaviors)
 		{
-			connectionParameters.TemplateBehaviors.Add(p2PBehavior);
+			connectionParameters.TemplateBehaviors.Add(behavior);
 		}
 
 		if (useTor)

--- a/WalletWasabi/BitcoinP2p/P2pNetwork.cs
+++ b/WalletWasabi/BitcoinP2p/P2pNetwork.cs
@@ -43,8 +43,6 @@ public static class P2pNetwork
 	public static NodesGroup CreateNodesGroup(Network network, EndPoint? torSocks5EndPoint, string workDir, NodeBehavior[] behaviors)
 	{
 		var addressManagerFilePath = Path.Combine(workDir, $"AddressManager{network}.dat");
-		var connectionParameters = new NodeConnectionParameters();
-
 		var addressManager = LoadOrCreateAddressManager(addressManagerFilePath);
 
 		var useTor = torSocks5EndPoint is not null;
@@ -55,6 +53,7 @@ public static class P2pNetwork
 		};
 
 		var userAgent = Constants.UserAgents.RandomElement(SecureRandom.Instance);
+		var connectionParameters = new NodeConnectionParameters();
 		connectionParameters.UserAgent = userAgent;
 		connectionParameters.TemplateBehaviors.Add(addressManagerBehavior);
 		connectionParameters.EndpointConnector = new BestEffortEndpointConnector(MaximumNodeConnections / 2);


### PR DESCRIPTION
Synchronizing the chain of block headers is necessary to implement the p2p synchronization mechanism that will make Wasabi finally independent of a central server. 

Downloading the headers takes time (only first time) and requires disk space, however it brings also benefits. For example, the RPC synchronization requires 3 roundtrips (3 rpc calls) to the server: `blockheight -> getblockcount -> getblockhash -> getblockfilter` however, once we have the headers chain, we know the tip height and all the blockhashs, what will make the rpc synchronization much faster, specially when the server is located remotely.