### PR TITLE
.editorconfig: Make analyzers report only warnings when a violation i…

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -99,7 +99,7 @@ dotnet_style_qualification_for_method = false:warning
 dotnet_style_qualification_for_property = false:warning
 
 dotnet_style_object_initializer = false:warning
-dotnet_style_collection_initializer = true:warning
+dotnet_style_collection_initializer = true:suggestion
 dotnet_style_explicit_tuple_names = true:warning
 
 csharp_prefer_simple_default_expression = true:warning

--- a/.editorconfig
+++ b/.editorconfig
@@ -38,30 +38,30 @@ csharp_new_line_before_open_brace = all
 # Formatting - spacing options
 
 # require NO space between a cast and the value
-csharp_space_after_cast = false:error
+csharp_space_after_cast = false:warning
 # require a space before the colon for bases or interfaces in a type declaration
-csharp_space_after_colon_in_inheritance_clause = true:error
+csharp_space_after_colon_in_inheritance_clause = true:warning
 # require a space after a keyword in a control flow statement such as a for loop
-csharp_space_after_keywords_in_control_flow_statements = true:error
+csharp_space_after_keywords_in_control_flow_statements = true:warning
 # require a space before the colon for bases or interfaces in a type declaration
-csharp_space_before_colon_in_inheritance_clause = true:error
+csharp_space_before_colon_in_inheritance_clause = true:warning
 # remove space within empty argument list parentheses
-csharp_space_between_method_call_empty_parameter_list_parentheses = false:error
+csharp_space_between_method_call_empty_parameter_list_parentheses = false:warning
 # remove space between method call name and opening parenthesis
-csharp_space_between_method_call_name_and_opening_parenthesis = false:error
+csharp_space_between_method_call_name_and_opening_parenthesis = false:warning
 # do not place space characters after the opening parenthesis and before the closing parenthesis of a method call
-csharp_space_between_method_call_parameter_list_parentheses = false:error
+csharp_space_between_method_call_parameter_list_parentheses = false:warning
 # remove space within empty parameter list parentheses for a method declaration
-csharp_space_between_method_declaration_empty_parameter_list_parentheses = false:error
+csharp_space_between_method_declaration_empty_parameter_list_parentheses = false:warning
 # place a space character after the opening parenthesis and before the closing parenthesis of a method declaration parameter list.
-csharp_space_between_method_declaration_parameter_list_parentheses = false:error
+csharp_space_between_method_declaration_parameter_list_parentheses = false:warning
 
 # Formatting - wrapping options
 
 # leave code block on single line
-csharp_preserve_single_line_blocks = true:error
+csharp_preserve_single_line_blocks = true:warning
 # leave statements and member declarations on the same line
-csharp_preserve_single_line_statements = true:error
+csharp_preserve_single_line_statements = true:warning
 
 # Style - expression bodied member options
 
@@ -77,64 +77,64 @@ csharp_style_expression_bodied_properties = true:suggestion
 # Style - expression level options
 
 # prefer out variables to be declared inline in the argument list of a method call when possible
-csharp_style_inlined_variable_declaration = true:error
+csharp_style_inlined_variable_declaration = true:warning
 csharp_style_deconstructed_variable_declaration = false:warning
 # prefer the language keyword for member access expressions, instead of the type name, for types that have a keyword to represent them
-dotnet_style_predefined_type_for_member_access = true:error
+dotnet_style_predefined_type_for_member_access = true:warning
 
 # Style - language keyword and framework type options
 
 # prefer the language keyword for local variables, method parameters, and class members, instead of the type name, for types that have a keyword to represent them
-dotnet_style_predefined_type_for_locals_parameters_members = true:error
+dotnet_style_predefined_type_for_locals_parameters_members = true:warning
 
 # Style - qualification options
 
 # prefer events not to be prefaced with this. or Me. in Visual Basic
-dotnet_style_qualification_for_event = false:error
+dotnet_style_qualification_for_event = false:warning
 # prefer fields not to be prefaced with this. or Me. in Visual Basic
-dotnet_style_qualification_for_field = false:error
+dotnet_style_qualification_for_field = false:warning
 # prefer methods not to be prefaced with this. or Me. in Visual Basic
-dotnet_style_qualification_for_method = false:error
+dotnet_style_qualification_for_method = false:warning
 # prefer properties not to be prefaced with this. or Me. in Visual Basic
-dotnet_style_qualification_for_property = false:error
+dotnet_style_qualification_for_property = false:warning
 
 dotnet_style_object_initializer = false:warning
-dotnet_style_collection_initializer = true:error
-dotnet_style_explicit_tuple_names = true:error
+dotnet_style_collection_initializer = true:warning
+dotnet_style_explicit_tuple_names = true:warning
 
-csharp_prefer_simple_default_expression = true:error
+csharp_prefer_simple_default_expression = true:warning
 
 csharp_indent_case_contents = true:warning
 csharp_indent_switch_labels = true:warning
 csharp_style_namespace_declarations = file_scoped:warning
 
 # prefer 'is null' for reference equality checks
-dotnet_style_prefer_is_null_check_over_reference_equality_method = true:error
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:warning
 
 # prefer braces
-csharp_prefer_braces = true:error
+csharp_prefer_braces = true:warning
 
 # do not suggest readonly fields
-dotnet_style_readonly_field = false:error
+dotnet_style_readonly_field = false:warning
 
 # use expression body for lambdas
 csharp_style_expression_bodied_lambdas = true:suggestion
 
 # IDE0066: Convert switch statement to expression
-csharp_style_prefer_switch_expression = true:error
+csharp_style_prefer_switch_expression = true:warning
 
 # IDE0063: Use simple 'using' statement
-csharp_prefer_simple_using_statement = true:error
+csharp_prefer_simple_using_statement = true:warning
 
 # IDE0054: Use compound assignment
-dotnet_style_prefer_compound_assignment = true:error
+dotnet_style_prefer_compound_assignment = true:warning
 
 # IDE0062: Make local function 'static'
-csharp_prefer_static_local_function = true:error
+csharp_prefer_static_local_function = true:warning
 
 
 # name all constant or static fields using PascalCase
-dotnet_naming_rule.constant_or_static_fields_should_be_pascal_case.severity = error
+dotnet_naming_rule.constant_or_static_fields_should_be_pascal_case.severity = warning
 dotnet_naming_rule.constant_or_static_fields_should_be_pascal_case.symbols  = constant_or_static_fields
 dotnet_naming_rule.constant_or_static_fields_should_be_pascal_case.style    = pascal_case_style
 
@@ -145,7 +145,7 @@ dotnet_naming_symbols.constant_or_static_fields.required_modifiers = static
 dotnet_naming_style.pascal_case_style.capitalization = pascal_case
 
 # private fields should be _camelCase
-dotnet_naming_rule.camel_case_for_private_fields.severity = error
+dotnet_naming_rule.camel_case_for_private_fields.severity = warning
 dotnet_naming_rule.camel_case_for_private_fields.symbols  = private_fields
 dotnet_naming_rule.camel_case_for_private_fields.style    = camel_case_underscore_style
 
@@ -156,7 +156,7 @@ dotnet_naming_style.camel_case_underscore_style.required_prefix = _
 dotnet_naming_style.camel_case_underscore_style.capitalization = camel_case
 
 # No other public/protected/protected_internal/private_protected fields are allowed
-dotnet_naming_rule.disallowed_fields_rule.severity = error
+dotnet_naming_rule.disallowed_fields_rule.severity = warning
 dotnet_naming_rule.disallowed_fields_rule.symbols  = disallowed_fields_symbols
 dotnet_naming_rule.disallowed_fields_rule.style    = disallowed_fields_style
 
@@ -180,7 +180,7 @@ dotnet_naming_style.end_with_async.required_suffix = Async
 dotnet_naming_style.end_with_async.capitalization  = pascal_case
 
 # Interfaces must be IPascalCase
-dotnet_naming_rule.interfaces_I_pascal_case.severity = error
+dotnet_naming_rule.interfaces_I_pascal_case.severity = warning
 dotnet_naming_rule.interfaces_I_pascal_case.symbols  = interfaces_symbols
 dotnet_naming_rule.interfaces_I_pascal_case.style    = I_pascal_case_style
 
@@ -191,7 +191,7 @@ dotnet_naming_style.I_pascal_case_style.required_prefix = I
 dotnet_naming_style.I_pascal_case_style.capitalization = pascal_case
 
 # name most members using PascalCase (except interface, field, local, parameter, type_parameter)
-dotnet_naming_rule.most_members_must_be_pascal_case.severity = error
+dotnet_naming_rule.most_members_must_be_pascal_case.severity = warning
 dotnet_naming_rule.most_members_must_be_pascal_case.symbols  = most_members_symbols
 dotnet_naming_rule.most_members_must_be_pascal_case.style    = pascal_case_style
 
@@ -199,7 +199,7 @@ dotnet_naming_symbols.most_members_symbols.applicable_kinds   = class, struct, e
 dotnet_naming_symbols.most_members_symbols.applicable_accessibilities = *
 
 # name Local variables & parameters using camelCase
-dotnet_naming_rule.local_variables_and_parameters_camel_case.severity = error
+dotnet_naming_rule.local_variables_and_parameters_camel_case.severity = warning
 dotnet_naming_rule.local_variables_and_parameters_camel_case.symbols  = local_variables_and_parameters_symbols
 dotnet_naming_rule.local_variables_and_parameters_camel_case.style    = camel_case_style
 
@@ -208,7 +208,7 @@ dotnet_naming_symbols.local_variables_and_parameters_symbols.applicable_kinds = 
 dotnet_naming_style.camel_case_style.capitalization = camel_case
 
 # name local constant using PascalCase
-dotnet_naming_rule.local_const_pascal_case.severity = error
+dotnet_naming_rule.local_const_pascal_case.severity = warning
 dotnet_naming_rule.local_const_pascal_case.symbols  = local_const
 dotnet_naming_rule.local_const_pascal_case.style    = pascal_case_style
 
@@ -218,7 +218,7 @@ dotnet_naming_symbols.local_const.required_modifiers = const
 dotnet_naming_style.pascal_case_style.capitalization = pascal_case
 
 # all type parameters should be TPascalCase
-dotnet_naming_rule.type_parameters_T_pascal_case.severity = error
+dotnet_naming_rule.type_parameters_T_pascal_case.severity = warning
 dotnet_naming_rule.type_parameters_T_pascal_case.symbols  = type_parameters_symbols
 dotnet_naming_rule.type_parameters_T_pascal_case.style    = T_pascal_case_style
 
@@ -229,25 +229,25 @@ dotnet_naming_style.T_pascal_case_style.capitalization = pascal_case
 
 
 # IDE0004: Remove Unnecessary Cast
-dotnet_diagnostic.IDE0004.severity = error
+dotnet_diagnostic.IDE0004.severity = warning
 
 # IDE0019: Use pattern matching
-csharp_style_pattern_matching_over_as_with_null_check = true:error
+csharp_style_pattern_matching_over_as_with_null_check = true:warning
 
 # IDE0028: Simplify collection initialization
 dotnet_diagnostic.IDE0028.severity = silent
 
 # IDE0032: Use auto property
-dotnet_style_prefer_auto_properties = true:error
+dotnet_style_prefer_auto_properties = true:warning
 
 # IDE0056: Use index operator
-csharp_style_prefer_index_operator = true:error
+csharp_style_prefer_index_operator = true:warning
 
 # IDE0057: Use range operator
-csharp_style_prefer_range_operator = true:error
+csharp_style_prefer_range_operator = true:warning
 
 # IDE0071: Simplify interpolation
-dotnet_style_prefer_simplified_interpolation = true:error
+dotnet_style_prefer_simplified_interpolation = true:warning
 
 # IDE0080: Remove unnecessary suppression operator
 dotnet_diagnostic.IDE0080.severity = warning
@@ -327,4 +327,4 @@ dotnet_diagnostic.CA2200.severity = warning
 dotnet_diagnostic.xUnit1030.severity = warning
 
 # RS0030: Do not use banned APIs
-dotnet_diagnostic.RS0030.severity = error
+dotnet_diagnostic.RS0030.severity = warning

--- a/.editorconfig
+++ b/.editorconfig
@@ -327,4 +327,4 @@ dotnet_diagnostic.CA2200.severity = warning
 dotnet_diagnostic.xUnit1030.severity = warning
 
 # RS0030: Do not use banned APIs
-dotnet_diagnostic.RS0030.severity = warning
+dotnet_diagnostic.RS0030.severity = error


### PR DESCRIPTION
…s found

Using errors when an analyzer finds a redundant cast or something other rather trivial feels unnecessary and confusing. Having:

* Errors for build errors
* Warnings for violations of code style or other things that do not break build

feels like the common approach in many .NET projects.
