### PR TITLE
DualCurrencyEntryBox: Fix bug when amount is "lost"

### DIFF
--- a/WalletWasabi.Fluent/Controls/CurrencyEntryBox.axaml.cs
+++ b/WalletWasabi.Fluent/Controls/CurrencyEntryBox.axaml.cs
@@ -239,7 +239,7 @@ public partial class CurrencyEntryBox : TextBox
 			return false;
 		}
 
-		// Reject and dont process the input if the string doesn't match.
+		// Reject and don't process the input if the string doesn't match.
 		if (!match.Success)
 		{
 			return false;

--- a/WalletWasabi.Fluent/Controls/DualCurrencyEntryBox.axaml.cs
+++ b/WalletWasabi.Fluent/Controls/DualCurrencyEntryBox.axaml.cs
@@ -11,7 +11,6 @@ using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.VisualTree;
 using NBitcoin;
-using ReactiveUI;
 using WalletWasabi.Fluent.Extensions;
 using WalletWasabi.Userfacing;
 
@@ -238,6 +237,7 @@ public class DualCurrencyEntryBox : TemplatedControl
 
 	public ICommand FocusCommand { get; }
 
+	/// <param name="text">Text is a valid decimal value with correct decimal separator. However, it can contain spaces.</param>
 	private void InputText(string? text)
 	{
 		if (!_isTextInputFocused)
@@ -251,7 +251,7 @@ public class DualCurrencyEntryBox : TemplatedControl
 		}
 		else
 		{
-			if (decimal.TryParse(text, NumberStyles.Number, CurrencyInput.InvariantNumberFormat, out var decimalValue))
+			if (decimal.TryParse(text.Replace(" ", ""), NumberStyles.Number, CurrencyInput.InvariantNumberFormat, out var decimalValue))
 			{
 				SetBtcAmount(decimalValue);
 			}
@@ -273,7 +273,7 @@ public class DualCurrencyEntryBox : TemplatedControl
 		}
 		else
 		{
-			if (decimal.TryParse(text, NumberStyles.Number, CurrencyInput.InvariantNumberFormat, out var decimalValue))
+			if (decimal.TryParse(text.Replace(" ", ""), NumberStyles.Number, CurrencyInput.InvariantNumberFormat, out var decimalValue))
 			{
 				SetBtcAmount(FiatToBitcoin(decimalValue));
 			}
@@ -463,7 +463,7 @@ public class DualCurrencyEntryBox : TemplatedControl
 	}
 
 	// this is ugly, but I couldn't find another way to make tab key and automatic focus to work properly
-	// setting Grid.Column via pseudoclass based style doesn't work, not even using AffectsMeasure()... Avalonia bug?
+	// setting Grid.Column via pseudo-class based style doesn't work, not even using AffectsMeasure()... Avalonia bug?
 	private void ReorganizeVisuals()
 	{
 		if (LeftEntryBox is { } && RightEntryBox is { })

--- a/WalletWasabi.Fluent/Controls/DualCurrencyEntryBox.axaml.cs
+++ b/WalletWasabi.Fluent/Controls/DualCurrencyEntryBox.axaml.cs
@@ -251,7 +251,7 @@ public class DualCurrencyEntryBox : TemplatedControl
 		}
 		else
 		{
-			if (decimal.TryParse(text.Replace(" ", ""), NumberStyles.Number, CurrencyInput.InvariantNumberFormat, out var decimalValue))
+			if (decimal.TryParse(RemoveFormat(text), NumberStyles.Number, CurrencyInput.InvariantNumberFormat, out var decimalValue))
 			{
 				SetBtcAmount(decimalValue);
 			}
@@ -273,7 +273,7 @@ public class DualCurrencyEntryBox : TemplatedControl
 		}
 		else
 		{
-			if (decimal.TryParse(text.Replace(" ", ""), NumberStyles.Number, CurrencyInput.InvariantNumberFormat, out var decimalValue))
+			if (decimal.TryParse(RemoveFormat(text), NumberStyles.Number, CurrencyInput.InvariantNumberFormat, out var decimalValue))
 			{
 				SetBtcAmount(FiatToBitcoin(decimalValue));
 			}


### PR DESCRIPTION
This PR fixes the following bug:

1. Open "Send" dialog
2. Copy and paste `0.01023` to the "Amount:" as a BTC value.
3. Click the "Recipient" text box

Value `0.01023` gets lost on master.