### PR TITLE
TransactionProcessor: Add wallet name to `WalletRelevantTransactionPr…

### DIFF
--- a/WalletWasabi.Fluent/Models/Wallets/WalletTransactionsModel.cs
+++ b/WalletWasabi.Fluent/Models/Wallets/WalletTransactionsModel.cs
@@ -48,6 +48,7 @@ public class WalletTransactionsModel : ReactiveObject, IDisposable
 
 		NewTransactionArrived =
 			services.EventBus.AsObservable<WalletRelevantTransactionProcessed>()
+				.Where(x => x.WalletName == wallet.WalletName)
 				.Select(x => (walletModel, x.Result))
 				.ObserveOn(RxApp.MainThreadScheduler);
 

--- a/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
+++ b/WalletWasabi/Blockchain/TransactionProcessing/TransactionProcessor.cs
@@ -57,7 +57,7 @@ public class TransactionProcessor
 
 		foreach (var result in results.Where(x => x.IsNews))
 		{
-			_eventBus.Publish(new WalletRelevantTransactionProcessed(result));
+			_eventBus.Publish(new WalletRelevantTransactionProcessed(KeyManager.WalletName, result));
 		}
 
 		return results;
@@ -79,17 +79,19 @@ public class TransactionProcessor
 
 	public ProcessedResult Process(SmartTransaction tx)
 	{
-		ProcessedResult ret;
+		ProcessedResult result;
 		lock (Lock)
 		{
 			_aware.Add(tx.GetHash());
-			ret = ProcessNoLock(tx);
+			result = ProcessNoLock(tx);
 		}
-		if (ret.IsNews)
+
+		if (result.IsNews)
 		{
-			_eventBus.Publish(new WalletRelevantTransactionProcessed(ret));
+			_eventBus.Publish(new WalletRelevantTransactionProcessed(KeyManager.WalletName, result));
 		}
-		return ret;
+
+		return result;
 	}
 
 	private ProcessedResult ProcessNoLock(SmartTransaction tx)

--- a/WalletWasabi/Services/EventBus.cs
+++ b/WalletWasabi/Services/EventBus.cs
@@ -129,4 +129,4 @@ public record WalletLoaded(Wallet Wallet);
 public record NewTransactionInMempool(SmartTransaction Transaction);
 public record ChainReorganized(FilterModel Filter);
 public record FiltersReceived(FilterModel[] Filters);
-public record WalletRelevantTransactionProcessed(ProcessedResult Result);
+public record WalletRelevantTransactionProcessed(string WalletName, ProcessedResult Result);

--- a/WalletWasabi/Wallets/Wallet.cs
+++ b/WalletWasabi/Wallets/Wallet.cs
@@ -69,7 +69,13 @@ public class Wallet : BackgroundService
 
 		_eventBus.Subscribe<MiningFeeRatesChanged>(e => FeeRateEstimations = e.AllFeeEstimate)
 			.DisposeUsing(_disposables);
-		_eventBus.Subscribe<WalletRelevantTransactionProcessed>(e => WalletRelevantTransactionProcessed(e.Result))
+		_eventBus.Subscribe<WalletRelevantTransactionProcessed>(e =>
+		{
+			if (e.WalletName == WalletName)
+			{
+				WalletRelevantTransactionProcessed(e.Result);
+			}
+		})
 			.DisposeUsing(_disposables);
 		_eventBus.Subscribe<NewTransactionInMempool>(e => Mempool_TransactionReceived(e.Transaction))
 			.DisposeUsing(_disposables);


### PR DESCRIPTION
…ocessed`

Closes #14561

I tested on the mainnet and it seems like it behaves correctly. I sent a transaction from one wallet to another one and I did not see any duplicate notifications. Testing with regtest would be easier, I guess, but it's not set up on my machine.