### PR TITLE
SleepInhibitor: Log only on change

### DIFF
--- a/WalletWasabi/Services/SleepInhibitor.cs
+++ b/WalletWasabi/Services/SleepInhibitor.cs
@@ -79,7 +79,6 @@ public class SleepInhibitor : PeriodicRunner
 		switch (highestCoinJoinClientState)
 		{
 			case CoinJoinClientState.Idle:
-				Logger.LogTrace("Computer idle state is allowed again.");
 				await StopTaskAsync().ConfigureAwait(false);
 				break;
 
@@ -116,6 +115,7 @@ public class SleepInhibitor : PeriodicRunner
 	{
 		if (_powerSavingTask is not null)
 		{
+			Logger.LogTrace("Computer idle state is allowed again.");
 			await _powerSavingTask.StopAsync().ConfigureAwait(false);
 			_powerSavingTask = null;
 		}

--- a/WalletWasabi/Services/SleepInhibitor.cs
+++ b/WalletWasabi/Services/SleepInhibitor.cs
@@ -61,12 +61,6 @@ public class SleepInhibitor : PeriodicRunner
 		}
 		else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
 		{
-			// Windows 7 does not support the API we use.
-			if (Environment.OSVersion.Version.Major < 10)
-			{
-				return null;
-			}
-
 			taskFactory = () => Task.FromResult<IPowerSavingInhibitorTask>(WindowsPowerAvailabilityTask.Create(Reason));
 		}
 


### PR DESCRIPTION
I wanted to see logs when testing #14546 and the sleep inhibitor populates the logs needlessly. This is a trivial fix for it.